### PR TITLE
cbor encode header before hmac

### DIFF
--- a/lib/mac.js
+++ b/lib/mac.js
@@ -28,7 +28,6 @@ const COSEAlgToNodeAlg = {
 
 function doMac (context, p, externalAAD, payload, alg, key) {
   return new Promise((resolve, reject) => {
-    p = (!p.size) ? EMPTY_BUFFER : p;
     const MACstructure = [
       context, // 'MAC0' or 'MAC1', // context
       p, // protected
@@ -63,6 +62,7 @@ exports.create = function (headers, payload, recipents, externalAAD, options) {
     throw new Error('There has to be at least one recipent');
   }
 
+  p = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
   if (recipents.length === 1) {
     // TODO check crit headers
     return doMac('MAC0',
@@ -72,8 +72,6 @@ exports.create = function (headers, payload, recipents, externalAAD, options) {
       COSEAlgToNodeAlg[AlgFromTags[alg]],
       recipents[0].key)
     .then((tag) => {
-      p = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
-
       if (options.excludetag) {
         return cbor.encode([p, u, payload, tag]);
       } else {


### PR DESCRIPTION
cbor encode header before hmac, see https://github.com/cose-wg/Examples/blob/master/hmac-examples/HMac-enc-05.json#L27 for correct intermediates