### PR TITLE
introduce synchronous sign+verify

### DIFF
--- a/lib/sign.js
+++ b/lib/sign.js
@@ -31,38 +31,35 @@ const COSEAlgToNodeAlg = {
 };
 
 function doSign (SigStructure, signer, alg) {
-  return new Promise((resolve, reject) => {
-    if (!AlgFromTags[alg]) {
-      throw new Error('Unknown algorithm, ' + alg);
-    }
-    if (!COSEAlgToNodeAlg[AlgFromTags[alg].sign]) {
-      throw new Error('Unsupported algorithm, ' + AlgFromTags[alg].sign);
-    }
+  if (!AlgFromTags[alg]) {
+    throw new Error('Unknown algorithm, ' + alg);
+  }
+  if (!COSEAlgToNodeAlg[AlgFromTags[alg].sign]) {
+    throw new Error('Unsupported algorithm, ' + AlgFromTags[alg].sign);
+  }
 
-    let ToBeSigned = cbor.encode(SigStructure);
+  let ToBeSigned = cbor.encode(SigStructure);
 
-    let sig;
-    if (AlgFromTags[alg].sign.startsWith('ES')) {
-      const hash = crypto.createHash(COSEAlgToNodeAlg[AlgFromTags[alg].sign].digest);
-      hash.update(ToBeSigned);
-      ToBeSigned = hash.digest();
-      const ec = new EC(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
-      const key = ec.keyFromPrivate(signer.key.d);
-      const signature = key.sign(ToBeSigned);
-      const bitLength = Math.ceil(ec.curve._bitLength / 8);
-      sig = Buffer.concat([signature.r.toArrayLike(Buffer, undefined, bitLength), signature.s.toArrayLike(Buffer, undefined, bitLength)]);
-    } else {
-      const sign = crypto.createSign(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
-      sign.update(ToBeSigned);
-      sign.end();
-      sig = sign.sign(signer.key);
-    }
-
-    resolve(sig);
-  });
+  let sig;
+  if (AlgFromTags[alg].sign.startsWith('ES')) {
+    const hash = crypto.createHash(COSEAlgToNodeAlg[AlgFromTags[alg].sign].digest);
+    hash.update(ToBeSigned);
+    ToBeSigned = hash.digest();
+    const ec = new EC(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
+    const key = ec.keyFromPrivate(signer.key.d);
+    const signature = key.sign(ToBeSigned);
+    const bitLength = Math.ceil(ec.curve._bitLength / 8);
+    sig = Buffer.concat([signature.r.toArrayLike(Buffer, undefined, bitLength), signature.s.toArrayLike(Buffer, undefined, bitLength)]);
+  } else {
+    const sign = crypto.createSign(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
+    sign.update(ToBeSigned);
+    sign.end();
+    sig = sign.sign(signer.key);
+  }
+  return sig;
 }
 
-exports.create = function (headers, payload, signers, options) {
+exports.createSync = function (headers, payload, signers, options) {
   options = options || {};
   let u = headers.u || {};
   let p = headers.p || {};
@@ -96,15 +93,14 @@ exports.create = function (headers, payload, signers, options) {
       externalAAD,
       payload
     ];
-    return doSign(SigStructure, signer, alg).then((sig) => {
-      if (p.size === 0 && options.encodep === 'empty') {
-        p = EMPTY_BUFFER;
-      } else {
-        p = cbor.encode(p);
-      }
-      const signed = [p, u, payload, [[signerP, signerU, sig]]];
-      return cbor.encode(options.excludetag ? signed : new Tagged(SignTag, signed));
-    });
+    const sig = doSign(SigStructure, signer, alg);
+    if (p.size === 0 && options.encodep === 'empty') {
+      p = EMPTY_BUFFER;
+    } else {
+      p = cbor.encode(p);
+    }
+    const signed = [p, u, payload, [[signerP, signerU, sig]]];
+    return cbor.encode(options.excludetag ? signed : new Tagged(SignTag, signed));
   } else {
     const signer = signers;
     const externalAAD = signer.externalAAD || EMPTY_BUFFER;
@@ -115,52 +111,56 @@ exports.create = function (headers, payload, signers, options) {
       externalAAD,
       payload
     ];
-    return doSign(SigStructure, signer, alg).then((sig) => {
-      if (p.size === 0 && options.encodep === 'empty') {
-        p = EMPTY_BUFFER;
-      } else {
-        p = cbor.encode(p);
-      }
-      const signed = [p, u, payload, sig];
-      return cbor.encodeCanonical(options.excludetag ? signed : new Tagged(Sign1Tag, signed));
-    });
+    const sig = doSign(SigStructure, signer, alg);
+    if (p.size === 0 && options.encodep === 'empty') {
+      p = EMPTY_BUFFER;
+    } else {
+      p = cbor.encode(p);
+    }
+    const signed = [p, u, payload, sig];
+    return cbor.encodeCanonical(options.excludetag ? signed : new Tagged(Sign1Tag, signed));
   }
 };
 
-function doVerify (SigStructure, verifier, alg, sig) {
+exports.create = function (headers, payload, signers, options) {
   return new Promise((resolve, reject) => {
-    if (!AlgFromTags[alg]) {
-      throw new Error('Unknown algorithm, ' + alg);
-    }
-    if (!COSEAlgToNodeAlg[AlgFromTags[alg].sign]) {
-      throw new Error('Unsupported algorithm, ' + AlgFromTags[alg].sign);
-    }
-    const ToBeSigned = cbor.encode(SigStructure);
-
-    if (AlgFromTags[alg].sign.startsWith('ES')) {
-      const hash = crypto.createHash(COSEAlgToNodeAlg[AlgFromTags[alg].sign].digest);
-      hash.update(ToBeSigned);
-      const msgHash = hash.digest();
-
-      const pub = { 'x': verifier.key.x, 'y': verifier.key.y };
-      const ec = new EC(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
-      const key = ec.keyFromPublic(pub);
-      sig = { 'r': sig.slice(0, sig.length / 2), 's': sig.slice(sig.length / 2) };
-      if (key.verify(msgHash, sig)) {
-        resolve();
-      } else {
-        throw new Error('Signature missmatch');
-      }
-    } else {
-      const verify = crypto.createVerify(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
-      verify.update(ToBeSigned);
-      if (verify.verify(verifier.key, sig)) {
-        resolve();
-      } else {
-        throw new Error('Signature missmatch');
-      }
-    }
+    const internal = exports.createSync(headers, payload, signers, options);
+    resolve(internal);
   });
+};
+
+function doVerify (SigStructure, verifier, alg, sig) {
+  if (!AlgFromTags[alg]) {
+    throw new Error('Unknown algorithm, ' + alg);
+  }
+  if (!COSEAlgToNodeAlg[AlgFromTags[alg].sign]) {
+    throw new Error('Unsupported algorithm, ' + AlgFromTags[alg].sign);
+  }
+  const ToBeSigned = cbor.encode(SigStructure);
+
+  if (AlgFromTags[alg].sign.startsWith('ES')) {
+    const hash = crypto.createHash(COSEAlgToNodeAlg[AlgFromTags[alg].sign].digest);
+    hash.update(ToBeSigned);
+    const msgHash = hash.digest();
+
+    const pub = { 'x': verifier.key.x, 'y': verifier.key.y };
+    const ec = new EC(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
+    const key = ec.keyFromPublic(pub);
+    sig = { 'r': sig.slice(0, sig.length / 2), 's': sig.slice(sig.length / 2) };
+    if (key.verify(msgHash, sig)) {
+
+    } else {
+      throw new Error('Signature missmatch');
+    }
+  } else {
+    const verify = crypto.createVerify(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
+    verify.update(ToBeSigned);
+    if (verify.verify(verifier.key, sig)) {
+
+    } else {
+      throw new Error('Signature missmatch');
+    }
+  }
 }
 
 function getSigner (signers, verifier) {
@@ -187,71 +187,78 @@ exports.verify = function (payload, verifier, options) {
   options = options || {};
   return cbor.decodeFirst(payload)
     .then((obj) => {
-      let type = options.defaultType ? options.defaultType : SignTag;
-      if (obj instanceof Tagged) {
-        if (obj.tag !== SignTag && obj.tag !== Sign1Tag) {
-          throw new Error('Unexpected cbor tag, \'' + obj.tag + '\'');
-        }
-        type = obj.tag;
-        obj = obj.value;
-      }
-
-      if (!Array.isArray(obj)) {
-        throw new Error('Expecting Array');
-      }
-
-      if (obj.length !== 4) {
-        throw new Error('Expecting Array of lenght 4');
-      }
-
-      let [p, u, plaintext, signers] = obj;
-
-      if (type === SignTag && !Array.isArray(signers)) {
-        throw new Error('Expecting signature Array');
-      }
-
-      p = (!p.length) ? EMPTY_BUFFER : cbor.decodeFirstSync(p);
-      u = (!u.size) ? EMPTY_BUFFER : u;
-
-      let signer = (type === SignTag ? getSigner(signers, verifier) : signers);
-
-      if (!signer) {
-        throw new Error('Failed to find signer with kid' + verifier.key.kid);
-      }
-
-      if (type === SignTag) {
-        const externalAAD = verifier.externalAAD || EMPTY_BUFFER;
-        let [signerP, , sig] = signer;
-        signerP = (!signerP.length) ? EMPTY_BUFFER : signerP;
-        p = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
-        const signerPMap = cbor.decode(signerP);
-        const alg = signerPMap.get(common.HeaderParameters.alg);
-        const SigStructure = [
-          'Signature',
-          p,
-          signerP,
-          externalAAD,
-          plaintext
-        ];
-        return doVerify(SigStructure, verifier, alg, sig)
-          .then(() => {
-            return plaintext;
-          });
-      } else {
-        const externalAAD = verifier.externalAAD || EMPTY_BUFFER;
-
-        const alg = getCommonParameter(p, u, common.HeaderParameters.alg);
-        p = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
-        const SigStructure = [
-          'Signature1',
-          p,
-          externalAAD,
-          plaintext
-        ];
-        return doVerify(SigStructure, verifier, alg, signer)
-          .then(() => {
-            return plaintext;
-          });
-      }
+      return verifyInternal(verifier, options, obj);
     });
 };
+
+exports.verifySync = function (payload, verifier, options) {
+  options = options || {};
+  let obj = cbor.decodeFirstSync(payload);
+  return verifyInternal(verifier, options, obj);
+};
+
+function verifyInternal (verifier, options, obj) {
+  options = options || {};
+  let type = options.defaultType ? options.defaultType : SignTag;
+  if (obj instanceof Tagged) {
+    if (obj.tag !== SignTag && obj.tag !== Sign1Tag) {
+      throw new Error('Unexpected cbor tag, \'' + obj.tag + '\'');
+    }
+    type = obj.tag;
+    obj = obj.value;
+  }
+
+  if (!Array.isArray(obj)) {
+    throw new Error('Expecting Array');
+  }
+
+  if (obj.length !== 4) {
+    throw new Error('Expecting Array of lenght 4');
+  }
+
+  let [p, u, plaintext, signers] = obj;
+
+  if (type === SignTag && !Array.isArray(signers)) {
+    throw new Error('Expecting signature Array');
+  }
+
+  p = (!p.length) ? EMPTY_BUFFER : cbor.decodeFirstSync(p);
+  u = (!u.size) ? EMPTY_BUFFER : u;
+
+  let signer = (type === SignTag ? getSigner(signers, verifier) : signers);
+
+  if (!signer) {
+    throw new Error('Failed to find signer with kid' + verifier.key.kid);
+  }
+
+  if (type === SignTag) {
+    const externalAAD = verifier.externalAAD || EMPTY_BUFFER;
+    let [signerP, , sig] = signer;
+    signerP = (!signerP.length) ? EMPTY_BUFFER : signerP;
+    p = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
+    const signerPMap = cbor.decode(signerP);
+    const alg = signerPMap.get(common.HeaderParameters.alg);
+    const SigStructure = [
+      'Signature',
+      p,
+      signerP,
+      externalAAD,
+      plaintext
+    ];
+    doVerify(SigStructure, verifier, alg, sig);
+    return plaintext;
+  } else {
+    const externalAAD = verifier.externalAAD || EMPTY_BUFFER;
+
+    const alg = getCommonParameter(p, u, common.HeaderParameters.alg);
+    p = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
+    const SigStructure = [
+      'Signature1',
+      p,
+      externalAAD,
+      plaintext
+    ];
+    doVerify(SigStructure, verifier, alg, signer);
+    return plaintext;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -721,6 +721,18 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -4518,6 +4530,17 @@
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3"
+      }
+    },
+    "jwk-to-pem": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.5.tgz",
+      "integrity": "sha512-L90jwellhO8jRKYwbssU9ifaMVqajzj3fpRjDKcsDzrslU9syRbFqfkXtT4B89HYAap+xsxNcxgBSB09ig+a7A==",
+      "dev": true,
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "elliptic": "^6.5.4",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {

--- a/test/rsa-pkcs-examples.js
+++ b/test/rsa-pkcs-examples.js
@@ -51,6 +51,42 @@ test('create rsa-pkcs-01', (t) => {
     });
 });
 
+test('create rsa-pkcs-01 Sync', (t) => {
+  const example = jsonfile.readFileSync('test/rsa-pkcs-examples/rsa-pkcs-01.json');
+  const p = example.input.sign0.protected;
+  const u = example.input.sign0.unprotected;
+  const plaintext = Buffer.from(example.input.plaintext);
+
+  const testKey = example.input.sign0.key;
+  const signer = {
+    'key': jwkToPem({
+      'kty': testKey.kty,
+      'n': hexToB64(testKey.n_hex),
+      'e': hexToB64(testKey.e_hex),
+      'd': hexToB64(testKey.d_hex),
+      'p': hexToB64(testKey.p_hex),
+      'q': hexToB64(testKey.q_hex),
+      'dp': hexToB64(testKey.dP_hex),
+      'dq': hexToB64(testKey.dQ_hex),
+      'qi': hexToB64(testKey.qi_hex)
+    }, { private: true })
+  };
+
+  const buf = cose.sign.createSync(
+    { 'p': p, 'u': u },
+    plaintext,
+    signer,
+    {
+      'excludetag': true
+    }
+  );
+  t.true(Buffer.isBuffer(buf));
+  t.true(buf.length > 0);
+  const actual = cbor.decodeFirstSync(buf);
+  const expected = cbor.decodeFirstSync(example.output.cbor);
+  t.true(deepEqual(actual, expected));
+});
+
 test('verify rsa-pkcs-01', (t) => {
   const example = jsonfile.readFileSync('test/rsa-pkcs-examples/rsa-pkcs-01.json');
 
@@ -77,4 +113,31 @@ test('verify rsa-pkcs-01', (t) => {
       t.true(buf.length > 0);
       t.is(buf.toString('utf8'), example.input.plaintext);
     });
+});
+
+test('verify rsa-pkcs-01 Sync', (t) => {
+  const example = jsonfile.readFileSync('test/rsa-pkcs-examples/rsa-pkcs-01.json');
+
+  const testKey = example.input.sign0.key;
+
+  const verifier = {
+    'key': jwkToPem({
+      'kty': testKey.kty,
+      'n': hexToB64(testKey.n_hex),
+      'e': hexToB64(testKey.e_hex)
+    })
+  };
+
+  const signature = Buffer.from(example.output.cbor, 'hex');
+
+  const buf = cose.sign.verifySync(
+    signature,
+    verifier,
+    {
+      'defaultType': cose.sign.Sign1Tag
+    });
+
+  t.true(Buffer.isBuffer(buf));
+  t.true(buf.length > 0);
+  t.is(buf.toString('utf8'), example.input.plaintext);
 });

--- a/test/sign-tests.js
+++ b/test/sign-tests.js
@@ -87,6 +87,32 @@ test('create sign-pass-01', (t) => {
     });
 });
 
+test('create sign-pass-01 Sync', (t) => {
+  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-01.json');
+  const p = example.input.sign.protected;
+  const u = example.input.sign.unprotected;
+  const plaintext = Buffer.from(example.input.plaintext);
+
+  const signers = [{
+    'key': {
+      'd': base64url.toBuffer(example.input.sign.signers[0].key.d)
+    },
+    'u': example.input.sign.signers[0].unprotected,
+    'p': example.input.sign.signers[0].protected
+  }];
+
+  const buf = cose.sign.createSync(
+    { 'p': p, 'u': u },
+    plaintext,
+    signers
+  );
+  t.true(Buffer.isBuffer(buf));
+  t.true(buf.length > 0);
+  const actual = cbor.decodeFirstSync(buf);
+  const expected = cbor.decodeFirstSync(example.output.cbor);
+  t.true(deepEqual(actual, expected));
+});
+
 test('create sign-pass-02', (t) => {
   const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-02.json');
   const p = example.input.sign.protected;
@@ -170,6 +196,27 @@ test('verify sign-pass-01', (t) => {
       t.true(buf.length > 0);
       t.is(buf.toString('utf8'), example.input.plaintext);
     });
+});
+
+test('verify sign-pass-01 Sync', (t) => {
+  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-01.json');
+
+  const verifier = {
+    'key': {
+      'x': base64url.toBuffer(example.input.sign.signers[0].key.x),
+      'y': base64url.toBuffer(example.input.sign.signers[0].key.y),
+      'kid': example.input.sign.signers[0].key.kid
+    }
+  };
+
+  const signature = Buffer.from(example.output.cbor, 'hex');
+
+  const buf = cose.sign.verifySync(
+    signature,
+    verifier);
+  t.true(Buffer.isBuffer(buf));
+  t.true(buf.length > 0);
+  t.is(buf.toString('utf8'), example.input.plaintext);
 });
 
 test('verify sign-pass-02', (t) => {


### PR DESCRIPTION
exports  synchronous functions `verifySync` and `createSync` in addition to the promise-based ones