### PR TITLE
fix encoding of kid header

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -53,7 +53,7 @@ const AlgToTags = {
 
 const Translators = {
   kid: (value) => {
-    return Buffer.from(value, 'utf8');
+    return value;
   },
   alg: (value) => {
     if (!(AlgToTags[value])) {


### PR DESCRIPTION
So this is required for WHO GDHCN verification, where the kid must be a TEXT_STRING not a BYTE_STRING. I'm not sure of that reading of the COSE/CBOR spec myself, but that's what they're saying. This fix means that the GDHCN validator at https://gdhcn-validator.net/validate will read the kid correctly. 

Maybe it should be an option somewhere? I'm not sure. but I can't use the unmodified code library and make the GDHCN validator happy