### PR TITLE
Consolidate shared logic, extract ECDH module, add EC key validation

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -2,6 +2,9 @@
 /* jslint node: true */
 'use strict';
 
+const cbor = require('cbor');
+const Tagged = cbor.Tagged;
+
 const AlgToTags = {
   PS512: -39,
   PS384: -38,
@@ -51,6 +54,16 @@ const AlgToTags = {
   'AES-CCM-64-256/128': 33
 };
 
+// Reverse mapping: COSE integer tag → canonical algorithm name.
+// "First entry wins" so that aliases don't overwrite the primary name.
+const TagsToAlg = {};
+for (const name in AlgToTags) {
+  const tag = AlgToTags[name];
+  if (TagsToAlg[tag] === undefined) {
+    TagsToAlg[tag] = name;
+  }
+}
+
 const Translators = {
   kid: (value) => {
     return Buffer.from(value, 'utf8');
@@ -79,7 +92,8 @@ const HeaderParameters = {
   x5chain: 33
 };
 
-exports.EMPTY_BUFFER = Buffer.alloc(0);
+const EMPTY_BUFFER = Buffer.alloc(0);
+exports.EMPTY_BUFFER = EMPTY_BUFFER;
 
 exports.TranslateHeaders = function (header) {
   const result = new Map();
@@ -165,6 +179,43 @@ module.exports.xor = function (a, b) {
 };
 
 exports.HeaderParameters = HeaderParameters;
+exports.TagsToAlg = TagsToAlg;
+
+exports.getAlgorithm = function (p, u) {
+  let alg;
+  if (p && p.get) {
+    alg = p.get(HeaderParameters.alg);
+  }
+  if (!alg && u && u.get) {
+    alg = u.get(HeaderParameters.alg);
+  }
+  return alg;
+};
+
+exports.encodeProtected = function (p, options) {
+  options = options || {};
+  if (p.size === 0 && options.encodep === 'empty') {
+    return EMPTY_BUFFER;
+  }
+  return cbor.encode(p);
+};
+
+exports.validateMessage = function (obj, validTags) {
+  let type;
+  if (obj instanceof Tagged) {
+    if (validTags.indexOf(obj.tag) === -1) {
+      throw new Error('Unexpected cbor tag, \'' + obj.tag + '\'');
+    }
+    type = obj.tag;
+    obj = obj.value;
+  }
+
+  if (!Array.isArray(obj)) {
+    throw new Error('Expecting Array');
+  }
+
+  return { type: type, value: obj };
+};
 
 exports.runningInNode = function () {
   return Object.prototype.toString.call(global.process) === '[object process]';

--- a/lib/ecdh.js
+++ b/lib/ecdh.js
@@ -1,0 +1,119 @@
+/* jshint esversion: 6 */
+/* jslint node: true */
+'use strict';
+
+const crypto = require('crypto');
+const cbor = require('cbor');
+const EC = require('elliptic').ec;
+const HKDF = require('node-hkdf-sync');
+const common = require('./common');
+const EMPTY_BUFFER = common.EMPTY_BUFFER;
+
+const HKDFAlg = {
+  'ECDH-ES': 'sha256',
+  'ECDH-ES-512': 'sha512',
+  'ECDH-SS': 'sha256',
+  'ECDH-SS-512': 'sha512'
+};
+
+const nodeCRV = {
+  'P-521': 'secp521r1',
+  'P-256': 'prime256v1'
+};
+
+const ellipticCRV = {
+  'P-256': 'p256',
+  'P-521': 'p521'
+};
+
+const curveKeyLength = {
+  'P-521': 66,
+  'P-256': 32
+};
+
+const ecdhAlgorithms = ['ECDH-ES', 'ECDH-ES-512', 'ECDH-SS', 'ECDH-SS-512'];
+
+exports.isECDH = function (alg) {
+  return ecdhAlgorithms.indexOf(alg) !== -1;
+};
+
+function isEphemeral (alg) {
+  return alg === 'ECDH-ES' || alg === 'ECDH-ES-512';
+}
+
+function createContext (rp, alg, keyLengthBits, partyUNonce) {
+  return cbor.encode([
+    alg,
+    [null, (partyUNonce || null), null],
+    [null, null, null],
+    [keyLengthBits, rp]
+  ]);
+}
+
+function validatePublicKey (crv, x, y) {
+  const ec = new EC(ellipticCRV[crv]);
+  const key = ec.keyFromPublic({ x: x, y: y });
+  const validation = key.validate();
+  if (!validation.result) {
+    throw new Error('Invalid recipient public key');
+  }
+}
+
+exports.deriveKey = function (recipient, contentAlg, contentKeyLength, randomSource) {
+  const crv = recipient.key.crv;
+
+  validatePublicKey(crv, recipient.key.x, recipient.key.y);
+
+  const recipientECDH = crypto.createECDH(nodeCRV[crv]);
+  const generated = crypto.createECDH(nodeCRV[crv]);
+  recipientECDH.setPrivateKey(recipient.key.d);
+
+  let pk;
+  if (isEphemeral(recipient.p.alg)) {
+    pk = randomSource(curveKeyLength[crv]);
+    pk[0] = (crv !== 'P-521' || pk[0] === 1) ? pk[0] : 0;
+  } else {
+    pk = recipient.sender.d;
+  }
+
+  generated.setPrivateKey(pk);
+  const senderPublicKey = generated.getPublicKey();
+
+  const recipientPublicKey = Buffer.concat([
+    Buffer.from('04', 'hex'),
+    recipient.key.x,
+    recipient.key.y
+  ]);
+
+  const generatedKey = common.TranslateKey({
+    crv: crv,
+    x: senderPublicKey.slice(1, curveKeyLength[crv] + 1),
+    y: senderPublicKey.slice(curveKeyLength[crv] + 1),
+    kty: 'EC2'
+  });
+
+  const rp = cbor.encode(common.TranslateHeaders(recipient.p));
+  const ikm = generated.computeSecret(recipientPublicKey);
+
+  let partyUNonce = null;
+  if (!isEphemeral(recipient.p.alg)) {
+    partyUNonce = randomSource(64);
+  }
+
+  const context = createContext(rp, contentAlg, contentKeyLength * 8, partyUNonce);
+  const hkdf = new HKDF(HKDFAlg[recipient.p.alg], undefined, ikm);
+  const key = hkdf.derive(context, contentKeyLength);
+
+  let ru = recipient.u;
+  if (isEphemeral(recipient.p.alg)) {
+    ru.ephemeral_key = generatedKey;
+  } else {
+    ru.static_key = generatedKey;
+  }
+  ru.partyUNonce = partyUNonce;
+  ru = common.TranslateHeaders(ru);
+
+  const recipientStruct = [[rp, ru, EMPTY_BUFFER]];
+
+  return { key: key, recipientStruct: recipientStruct };
+};

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -5,7 +5,7 @@
 const cbor = require('cbor');
 const crypto = require('crypto');
 const common = require('./common');
-const HKDF = require('node-hkdf-sync');
+const ecdh = require('./ecdh');
 
 const Tagged = cbor.Tagged;
 
@@ -15,22 +15,6 @@ const EncryptTag = exports.EncryptTag = 96;
 const Encrypt0Tag = exports.Encrypt0Tag = 16;
 
 const runningInNode = common.runningInNode;
-
-// Maps COSE algorithm integer IDs (RFC 8152 §10.1) to their string names.
-// These IDs appear in the protected/unprotected header 'alg' field.
-const TagToAlg = {
-  1: 'A128GCM',
-  2: 'A192GCM',
-  3: 'A256GCM',
-  10: 'AES-CCM-16-64-128',
-  11: 'AES-CCM-16-64-256',
-  12: 'AES-CCM-64-64-128',
-  13: 'AES-CCM-64-64-256',
-  30: 'AES-CCM-16-128-128',
-  31: 'AES-CCM-16-128-256',
-  32: 'AES-CCM-64-128-128',
-  33: 'AES-CCM-64-128-256'
-};
 
 // Maps COSE algorithm names to the cipher identifiers understood by Node's
 // built-in `crypto` module.
@@ -102,8 +86,7 @@ const ivLength = {
   33: 7 // AES-CCM-64-128-256
 };
 
-// Symmetric key lengths in bytes for each algorithm, plus EC curve sizes used
-// when deriving keys with ECDH (the curve's field size in bytes).
+// Symmetric key lengths in bytes for each algorithm.
 const keyLength = {
   1: 16, // A128GCM
   2: 24, // A192GCM
@@ -115,24 +98,7 @@ const keyLength = {
   30: 16, // AES-CCM-16-128-128
   31: 32, // AES-CCM-16-128-256
   32: 16, // AES-CCM-64-128-128
-  33: 32, // AES-CCM-64-128-256
-  'P-521': 66,
-  'P-256': 32
-};
-
-// HKDF hash algorithm to use when deriving a CEK via each ECDH key-agreement
-// variant (RFC 8152 §11.1).
-const HKDFAlg = {
-  'ECDH-ES': 'sha256',
-  'ECDH-ES-512': 'sha512',
-  'ECDH-SS': 'sha256',
-  'ECDH-SS-512': 'sha512'
-};
-
-// Maps COSE curve names to the OpenSSL names expected by Node's crypto module.
-const nodeCRV = {
-  'P-521': 'secp521r1',
-  'P-256': 'prime256v1'
+  33: 32 // AES-CCM-64-128-256
 };
 
 // Builds the Enc_structure (RFC 8152 §5.3) that is authenticated but not
@@ -156,7 +122,7 @@ function _randomSource (bytes) {
 // The auth tag is appended to the ciphertext so it can be transmitted as a
 // single opaque byte string (the COSE convention).
 function nodeEncrypt (payload, key, alg, iv, aad, ccm = false) {
-  const nodeAlg = COSEAlgToNodeAlg[TagToAlg[alg]];
+  const nodeAlg = COSEAlgToNodeAlg[common.TagsToAlg[alg]];
   // CCM requires the auth-tag length and plaintext length at cipher creation time.
   const chiperOptions = ccm ? { authTagLength: authTagLength[alg] } : null;
   const aadOptions = ccm ? { plaintextLength: Buffer.byteLength(payload) } : null;
@@ -166,28 +132,6 @@ function nodeEncrypt (payload, key, alg, iv, aad, ccm = false) {
     cipher.update(payload),
     cipher.final(),
     cipher.getAuthTag()
-  ]);
-}
-
-// Builds the HKDF PartyInfo / SuppPubInfo context structure (RFC 8152 §11.1)
-// used to derive the Content Encryption Key (CEK) from the ECDH shared secret.
-function createContext (rp, alg, partyUNonce) {
-  return cbor.encode([
-    alg, // AlgorithmID
-    [ // PartyUInfo
-      null, // identity
-      (partyUNonce || null), // nonce
-      null // other
-    ],
-    [ // PartyVInfo
-      null, // identity
-      null, // nonce
-      null // other
-    ],
-    [
-      keyLength[alg] * 8, // keyDataLength (bits)
-      rp // protected header of the recipient layer
-    ]
   ]);
 }
 
@@ -212,7 +156,7 @@ exports.create = async function (headers, payload, recipients, options) {
 
   // The content encryption algorithm must appear in either the protected or
   // unprotected header (protected takes precedence).
-  const alg = p.get(common.HeaderParameters.alg) || u.get(common.HeaderParameters.alg);
+  const alg = common.getAlgorithm(p, u);
 
   if (!alg) {
     throw new Error('Missing mandatory parameter \'alg\'');
@@ -245,86 +189,11 @@ exports.create = async function (headers, payload, recipients, options) {
 
     let key;
     let recipientStruct;
-    // TODO do a more accurate check
-    if (recipients[0] && recipients[0].p &&
-      (recipients[0].p.alg === 'ECDH-ES' ||
-        recipients[0].p.alg === 'ECDH-ES-512' ||
-        recipients[0].p.alg === 'ECDH-SS' ||
-        recipients[0].p.alg === 'ECDH-SS-512')) {
-      // --- ECDH key agreement ---
-      // Derive a CEK from the shared ECDH secret using HKDF. The CEK is never
-      // transmitted; the recipient recomputes it from the sender's public key.
-      const recipient = crypto.createECDH(nodeCRV[recipients[0].key.crv]);
-      const generated = crypto.createECDH(nodeCRV[recipients[0].key.crv]);
-      recipient.setPrivateKey(recipients[0].key.d);
-
-      // ECDH-ES: ephemeral sender key pair generated fresh for each message.
-      // ECDH-SS: static sender private key supplied by the caller.
-      let pk = randomSource(keyLength[recipients[0].key.crv]);
-      if (recipients[0].p.alg === 'ECDH-ES' ||
-        recipients[0].p.alg === 'ECDH-ES-512') {
-        pk = randomSource(keyLength[recipients[0].key.crv]);
-        // Ensure the leading byte is valid for P-521 (must be 0 or 1).
-        pk[0] = (recipients[0].key.crv !== 'P-521' || pk[0] === 1) ? pk[0] : 0;
-      } else {
-        pk = recipients[0].sender.d;
-      }
-
-      generated.setPrivateKey(pk);
-      const senderPublicKey = generated.getPublicKey();
-
-      // Reconstruct the recipient's uncompressed public key (0x04 || x || y).
-      const recipientPublicKey = Buffer.concat([
-        Buffer.from('04', 'hex'),
-        recipients[0].key.x,
-        recipients[0].key.y
-      ]);
-
-      // Build the COSE_Key representation of the sender's public key so it can
-      // be included in the recipient unprotected header for the receiver to use.
-      const generatedKey = common.TranslateKey({
-        crv: recipients[0].key.crv,
-        x: senderPublicKey.slice(1, keyLength[recipients[0].key.crv] + 1), // TODO slice based on key length
-        y: senderPublicKey.slice(keyLength[recipients[0].key.crv] + 1),
-        kty: 'EC2' // TODO use real value
-      });
-
-      // Compute the raw ECDH shared secret (IKM for HKDF).
-      const rp = cbor.encode(common.TranslateHeaders(recipients[0].p));
-      const ikm = generated.computeSecret(recipientPublicKey);
-
-      // ECDH-SS includes a sender-generated nonce in the HKDF context to
-      // prevent key reuse across messages that share the same static key pair.
-      let partyUNonce = null;
-      if (recipients[0].p.alg === 'ECDH-SS' || recipients[0].p.alg === 'ECDH-SS-512') {
-        partyUNonce = randomSource(64); // TODO use real value
-      }
-
-      // Derive the CEK from the shared secret via HKDF.
-      const context = createContext(rp, alg, partyUNonce);
-      const nrBytes = keyLength[alg];
-      const hkdf = new HKDF(HKDFAlg[recipients[0].p.alg], undefined, ikm);
-      key = hkdf.derive(context, nrBytes);
-
-      // Attach the sender's public key (or nonce) to the recipient unprotected
-      // header so the receiver can reproduce the shared secret.
-      let ru = recipients[0].u;
-      if (recipients[0].p.alg === 'ECDH-ES' ||
-        recipients[0].p.alg === 'ECDH-ES-512') {
-        ru.ephemeral_key = generatedKey;
-      } else {
-        ru.static_key = generatedKey;
-      }
-      ru.partyUNonce = partyUNonce;
-      ru = common.TranslateHeaders(ru);
-
-      // Recipient structure: [protected, unprotected, ciphertext].
-      // The recipient ciphertext is empty because ECDH-ES/SS uses direct key
-      // agreement — the CEK is derived, not wrapped.
-      recipientStruct = [[rp, ru, EMPTY_BUFFER]];
+    if (recipients[0] && recipients[0].p && ecdh.isECDH(recipients[0].p.alg)) {
+      const derived = ecdh.deriveKey(recipients[0], alg, keyLength[alg], randomSource);
+      key = derived.key;
+      recipientStruct = derived.recipientStruct;
     } else {
-      // --- Direct symmetric key ---
-      // The caller supplies the raw CEK; no key-wrapping is performed.
       key = recipients[0].key;
       const ru = common.TranslateHeaders(recipients[0].u);
       recipientStruct = [[EMPTY_BUFFER, ru, EMPTY_BUFFER]];
@@ -340,13 +209,7 @@ exports.create = async function (headers, payload, recipients, options) {
       throw new Error('No implementation for algorithm, ' + alg);
     }
 
-    // Encode the protected header. When encodep === 'empty' and there are no
-    // protected headers, use an empty bstr rather than an encoded empty map.
-    if (p.size === 0 && options.encodep === 'empty') {
-      p = EMPTY_BUFFER;
-    } else {
-      p = cbor.encode(p);
-    }
+    p = common.encodeProtected(p, options);
 
     // COSE_Encrypt: [protected, unprotected, ciphertext, [recipients]]
     const encrypted = [p, u, ciphertext, recipientStruct];
@@ -377,11 +240,7 @@ exports.create = async function (headers, payload, recipients, options) {
       throw new Error('No implementation for algorithm, ' + alg);
     }
 
-    if (p.size === 0 && options.encodep === 'empty') {
-      p = EMPTY_BUFFER;
-    } else {
-      p = cbor.encode(p);
-    }
+    p = common.encodeProtected(p, options);
 
     // COSE_Encrypt0: [protected, unprotected, ciphertext]
     const encrypted = [p, u, ciphertext];
@@ -392,7 +251,7 @@ exports.create = async function (headers, payload, recipients, options) {
 // Decrypts a single AES-GCM or AES-CCM ciphertext produced by nodeEncrypt.
 // The auth tag is expected to be appended to the ciphertext (COSE convention).
 function nodeDecrypt (ciphertext, key, alg, iv, tag, aad, ccm = false) {
-  const nodeAlg = COSEAlgToNodeAlg[TagToAlg[alg]];
+  const nodeAlg = COSEAlgToNodeAlg[common.TagsToAlg[alg]];
   const chiperOptions = ccm ? { authTagLength: authTagLength[alg] } : null;
   // CCM needs the ciphertext length (== plaintext length) before decryption starts.
   const aadOptions = ccm ? { plaintextLength: Buffer.byteLength(ciphertext) } : null;
@@ -411,18 +270,10 @@ exports.read = async function (data, key, options) {
 
   // Decode the outermost CBOR item. It may be a tagged or untagged array.
   let obj = await cbor.decodeFirst(data);
-  let msgTag = options.defaultType ? options.defaultType : EncryptTag;
-  if (obj instanceof Tagged) {
-    if (obj.tag !== EncryptTag && obj.tag !== Encrypt0Tag) {
-      throw new Error('Unknown tag, ' + obj.tag);
-    }
-    msgTag = obj.tag;
-    obj = obj.value;
-  }
 
-  if (!Array.isArray(obj)) {
-    throw new Error('Expecting Array');
-  }
+  const validated = common.validateMessage(obj, [EncryptTag, Encrypt0Tag]);
+  const msgTag = validated.type || (options.defaultType ? options.defaultType : EncryptTag);
+  obj = validated.value;
 
   // COSE_Encrypt has 4 elements; COSE_Encrypt0 has 3.
   if (msgTag === EncryptTag && obj.length !== 4) {
@@ -441,8 +292,8 @@ exports.read = async function (data, key, options) {
   u = (!u.size) ? EMPTY_BUFFER : u;
 
   // Algorithm is taken from the protected header first, then unprotected.
-  const alg = (p !== EMPTY_BUFFER) ? p.get(common.HeaderParameters.alg) : (u !== EMPTY_BUFFER) ? u.get(common.HeaderParameters.alg) : undefined;
-  if (!TagToAlg[alg]) {
+  const alg = common.getAlgorithm(p, u);
+  if (!common.TagsToAlg[alg]) {
     throw new Error('Unknown or unsupported algorithm ' + alg);
   }
 

--- a/lib/mac.js
+++ b/lib/mac.js
@@ -12,17 +12,6 @@ const EMPTY_BUFFER = common.EMPTY_BUFFER;
 const MAC0Tag = exports.MAC0Tag = 17;
 const MACTag = exports.MACTag = 97;
 
-const AlgFromTags = {
-  4: 'SHA-256_64',
-  5: 'SHA-256',
-  6: 'SHA-384',
-  7: 'SHA-512',
-  14: 'AES-MAC-128/64',
-  15: 'AES-MAC-256/64',
-  25: 'AES-MAC-128/128',
-  26: 'AES-MAC-256/128'
-};
-
 const COSEAlgToNodeAlg = {
   'SHA-256_64': 'sha256',
   'SHA-256': 'sha256',
@@ -75,7 +64,7 @@ exports.create = async function (headers, payload, recipents, externalAAD, optio
   p = common.TranslateHeaders(p);
   u = common.TranslateHeaders(u);
 
-  const alg = p.get(common.HeaderParameters.alg) || u.get(common.HeaderParameters.alg);
+  const alg = common.getAlgorithm(p, u);
 
   if (!alg) {
     throw new Error('Missing mandatory parameter \'alg\'');
@@ -86,25 +75,21 @@ exports.create = async function (headers, payload, recipents, externalAAD, optio
   }
 
   const predictableP = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
-  if (p.size === 0 && options.encodep === 'empty') {
-    p = EMPTY_BUFFER;
-  } else {
-    p = cbor.encode(p);
-  }
+  p = common.encodeProtected(p, options);
   // TODO check crit headers
   if (Array.isArray(recipents)) {
     if (recipents.length > 1) {
       throw new Error('MACing with multiple recipents is not implemented');
     }
     const recipent = recipents[0];
-    let tag = doMac('MAC', predictableP, externalAAD, payload, COSEAlgToNodeAlg[AlgFromTags[alg]], recipent.key);
+    let tag = doMac('MAC', predictableP, externalAAD, payload, COSEAlgToNodeAlg[common.TagsToAlg[alg]], recipent.key);
     tag = tag.slice(0, CutTo[alg]);
     const ru = common.TranslateHeaders(recipent.u);
     const rp = EMPTY_BUFFER;
     const maced = [p, u, payload, tag, [[rp, ru, EMPTY_BUFFER]]];
     return cbor.encode(options.excludetag ? maced : new Tagged(MACTag, maced));
   } else {
-    let tag = doMac('MAC0', predictableP, externalAAD, payload, COSEAlgToNodeAlg[AlgFromTags[alg]], recipents.key);
+    let tag = doMac('MAC0', predictableP, externalAAD, payload, COSEAlgToNodeAlg[common.TagsToAlg[alg]], recipents.key);
     tag = tag.slice(0, CutTo[alg]);
     const maced = [p, u, payload, tag];
     return cbor.encode(options.excludetag ? maced : new Tagged(MAC0Tag, maced));
@@ -117,18 +102,9 @@ exports.read = async function (data, key, externalAAD, options) {
 
   let obj = await cbor.decodeFirst(data);
 
-  let type = options.defaultType ? options.defaultType : MAC0Tag;
-  if (obj instanceof Tagged) {
-    if (obj.tag !== MAC0Tag && obj.tag !== MACTag) {
-      throw new Error('Unexpected cbor tag, \'' + obj.tag + '\'');
-    }
-    type = obj.tag;
-    obj = obj.value;
-  }
-
-  if (!Array.isArray(obj)) {
-    throw new Error('Expecting Array');
-  }
+  const validated = common.validateMessage(obj, [MAC0Tag, MACTag]);
+  const type = validated.type || (options.defaultType ? options.defaultType : MAC0Tag);
+  obj = validated.value;
 
   if (type === MAC0Tag && obj.length !== 4) {
     throw new Error('Expecting Array of length 4');
@@ -143,16 +119,16 @@ exports.read = async function (data, key, externalAAD, options) {
   u = (!u.size) ? EMPTY_BUFFER : u;
 
   // TODO validate protected header
-  const alg = (p !== EMPTY_BUFFER) ? p.get(common.HeaderParameters.alg) : (u !== EMPTY_BUFFER) ? u.get(common.HeaderParameters.alg) : undefined;
+  const alg = common.getAlgorithm(p, u);
   p = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
-  if (!AlgFromTags[alg]) {
+  if (!common.TagsToAlg[alg]) {
     throw new Error('Unknown algorithm, ' + alg);
   }
-  if (!COSEAlgToNodeAlg[AlgFromTags[alg]]) {
-    throw new Error('Unsupported algorithm, ' + AlgFromTags[alg]);
+  if (!COSEAlgToNodeAlg[common.TagsToAlg[alg]]) {
+    throw new Error('Unsupported algorithm, ' + common.TagsToAlg[alg]);
   }
 
-  let calcTag = doMac(context[type], p, externalAAD, payload, COSEAlgToNodeAlg[AlgFromTags[alg]], key);
+  let calcTag = doMac(context[type], p, externalAAD, payload, COSEAlgToNodeAlg[common.TagsToAlg[alg]], key);
   calcTag = calcTag.slice(0, CutTo[alg]);
   if (!crypto.timingSafeEqual(tag, calcTag)) {
     throw new Error('Tag mismatch');

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -13,17 +13,6 @@ const Tagged = cbor.Tagged;
 const SignTag = exports.SignTag = 98;
 const Sign1Tag = exports.Sign1Tag = 18;
 
-const AlgFromTags = {};
-AlgFromTags[-7] = { sign: 'ES256', digest: 'SHA-256' };
-AlgFromTags[-35] = { sign: 'ES384', digest: 'SHA-384' };
-AlgFromTags[-36] = { sign: 'ES512', digest: 'SHA-512' };
-AlgFromTags[-37] = { sign: 'PS256', digest: 'SHA-256' };
-AlgFromTags[-38] = { sign: 'PS384', digest: 'SHA-384' };
-AlgFromTags[-39] = { sign: 'PS512', digest: 'SHA-512' };
-AlgFromTags[-257] = { sign: 'RS256', digest: 'SHA-256' };
-AlgFromTags[-258] = { sign: 'RS384', digest: 'SHA-384' };
-AlgFromTags[-259] = { sign: 'RS512', digest: 'SHA-512' };
-
 const COSEAlgToNodeAlg = {
   ES256: { sign: 'p256', digest: 'sha256' },
   ES384: { sign: 'p384', digest: 'sha384' },
@@ -37,40 +26,42 @@ const COSEAlgToNodeAlg = {
 };
 
 function doSign (SigStructure, signer, alg) {
-  if (!AlgFromTags[alg]) {
+  const algName = common.TagsToAlg[alg];
+  if (!algName) {
     throw new Error('Unknown algorithm, ' + alg);
   }
-  if (!COSEAlgToNodeAlg[AlgFromTags[alg].sign]) {
-    throw new Error('Unsupported algorithm, ' + AlgFromTags[alg].sign);
+  const nodeAlg = COSEAlgToNodeAlg[algName];
+  if (!nodeAlg) {
+    throw new Error('Unsupported algorithm, ' + algName);
   }
 
   let ToBeSigned = cbor.encode(SigStructure);
 
   let sig;
-  if (AlgFromTags[alg].sign.startsWith('ES')) {
-    const hash = crypto.createHash(COSEAlgToNodeAlg[AlgFromTags[alg].sign].digest);
+  if (algName.startsWith('ES')) {
+    const hash = crypto.createHash(nodeAlg.digest);
     hash.update(ToBeSigned);
     ToBeSigned = hash.digest();
-    const ec = new EC(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
+    const ec = new EC(nodeAlg.sign);
     const key = ec.keyFromPrivate(signer.key.d);
     const signature = key.sign(ToBeSigned);
     const bitLength = Math.ceil(ec.curve._bitLength / 8);
     sig = Buffer.concat([signature.r.toArrayLike(Buffer, undefined, bitLength), signature.s.toArrayLike(Buffer, undefined, bitLength)]);
-  } else if (AlgFromTags[alg].sign.startsWith('PS')) {
+  } else if (algName.startsWith('PS')) {
     signer.key.dmp1 = signer.key.dp;
     signer.key.dmq1 = signer.key.dq;
     signer.key.coeff = signer.key.qi;
     const key = new NodeRSA().importKey(signer.key, 'components-private');
     key.setOptions({
       signingScheme: {
-        scheme: COSEAlgToNodeAlg[AlgFromTags[alg].sign].alg.split('-')[0],
-        hash: COSEAlgToNodeAlg[AlgFromTags[alg].sign].alg.split('-')[1],
-        saltLength: COSEAlgToNodeAlg[AlgFromTags[alg].sign].saltLen
+        scheme: nodeAlg.alg.split('-')[0],
+        hash: nodeAlg.alg.split('-')[1],
+        saltLength: nodeAlg.saltLen
       }
     });
     sig = key.sign(ToBeSigned);
   } else {
-    const sign = crypto.createSign(COSEAlgToNodeAlg[AlgFromTags[alg].sign].sign);
+    const sign = crypto.createSign(nodeAlg.sign);
     sign.update(ToBeSigned);
     sign.end();
     sig = sign.sign(signer.key);
@@ -114,17 +105,13 @@ exports.create = function (headers, payload, signers, options) {
     ];
 
     const sig = doSign(SigStructure, signer, alg);
-    if (p.size === 0 && options.encodep === 'empty') {
-      p = EMPTY_BUFFER;
-    } else {
-      p = cbor.encode(p);
-    }
+    p = common.encodeProtected(p, options);
     const signed = [p, u, payload, [[signerP, signerU, sig]]];
     return cbor.encodeAsync(options.excludetag ? signed : new Tagged(SignTag, signed));
   } else {
     const signer = signers;
     const externalAAD = signer.externalAAD || EMPTY_BUFFER;
-    const alg = p.get(common.HeaderParameters.alg) || u.get(common.HeaderParameters.alg);
+    const alg = common.getAlgorithm(p, u);
     const SigStructure = [
       'Signature1',
       bodyP,
@@ -132,27 +119,24 @@ exports.create = function (headers, payload, signers, options) {
       payload
     ];
     const sig = doSign(SigStructure, signer, alg);
-    if (p.size === 0 && options.encodep === 'empty') {
-      p = EMPTY_BUFFER;
-    } else {
-      p = cbor.encode(p);
-    }
+    p = common.encodeProtected(p, options);
     const signed = [p, u, payload, sig];
     return cbor.encodeAsync(options.excludetag ? signed : new Tagged(Sign1Tag, signed), { canonical: true });
   }
 };
 
 function doVerify (SigStructure, verifier, alg, sig) {
-  if (!AlgFromTags[alg]) {
+  const algName = common.TagsToAlg[alg];
+  if (!algName) {
     throw new Error('Unknown algorithm, ' + alg);
   }
-  const nodeAlg = COSEAlgToNodeAlg[AlgFromTags[alg].sign];
+  const nodeAlg = COSEAlgToNodeAlg[algName];
   if (!nodeAlg) {
-    throw new Error('Unsupported algorithm, ' + AlgFromTags[alg].sign);
+    throw new Error('Unsupported algorithm, ' + algName);
   }
   const ToBeSigned = cbor.encode(SigStructure);
 
-  if (AlgFromTags[alg].sign.startsWith('ES')) {
+  if (algName.startsWith('ES')) {
     const hash = crypto.createHash(nodeAlg.digest);
     hash.update(ToBeSigned);
     const msgHash = hash.digest();
@@ -160,17 +144,21 @@ function doVerify (SigStructure, verifier, alg, sig) {
     const pub = { x: verifier.key.x, y: verifier.key.y };
     const ec = new EC(nodeAlg.sign);
     const key = ec.keyFromPublic(pub);
+    const validation = key.validate();
+    if (!validation.result) {
+      throw new Error('Signature mismatch');
+    }
     sig = { r: sig.slice(0, sig.length / 2), s: sig.slice(sig.length / 2) };
     if (!key.verify(msgHash, sig)) {
       throw new Error('Signature mismatch');
     }
-  } else if (AlgFromTags[alg].sign.startsWith('PS')) {
+  } else if (algName.startsWith('PS')) {
     const key = new NodeRSA().importKey(verifier.key, 'components-public');
     key.setOptions({
       signingScheme: {
-        scheme: COSEAlgToNodeAlg[AlgFromTags[alg].sign].alg.split('-')[0],
-        hash: COSEAlgToNodeAlg[AlgFromTags[alg].sign].alg.split('-')[1],
-        saltLength: COSEAlgToNodeAlg[AlgFromTags[alg].sign].saltLen
+        scheme: nodeAlg.alg.split('-')[0],
+        hash: nodeAlg.alg.split('-')[1],
+        saltLength: nodeAlg.saltLen
       }
     });
     if (!key.verify(ToBeSigned, sig, 'buffer', 'buffer')) {
@@ -194,17 +182,6 @@ function getSigner (signers, verifier) {
   }
 }
 
-function getCommonParameter (first, second, parameter) {
-  let result;
-  if (first.get) {
-    result = first.get(parameter);
-  }
-  if (!result && second.get) {
-    result = second.get(parameter);
-  }
-  return result;
-}
-
 exports.verify = async function (payload, verifier, options) {
   options = options || {};
   const obj = await cbor.decodeFirst(payload);
@@ -219,18 +196,9 @@ exports.verifySync = function (payload, verifier, options) {
 
 function verifyInternal (verifier, options, obj) {
   options = options || {};
-  let type = options.defaultType ? options.defaultType : SignTag;
-  if (obj instanceof Tagged) {
-    if (obj.tag !== SignTag && obj.tag !== Sign1Tag) {
-      throw new Error('Unexpected cbor tag, \'' + obj.tag + '\'');
-    }
-    type = obj.tag;
-    obj = obj.value;
-  }
-
-  if (!Array.isArray(obj)) {
-    throw new Error('Expecting Array');
-  }
+  const validated = common.validateMessage(obj, [SignTag, Sign1Tag]);
+  const type = validated.type || (options.defaultType ? options.defaultType : SignTag);
+  obj = validated.value;
 
   if (obj.length !== 4) {
     throw new Error('Expecting Array of length 4');
@@ -270,7 +238,7 @@ function verifyInternal (verifier, options, obj) {
   } else {
     const externalAAD = verifier.externalAAD || EMPTY_BUFFER;
 
-    const alg = getCommonParameter(p, u, common.HeaderParameters.alg);
+    const alg = common.getAlgorithm(p, u);
     p = (!p.size) ? EMPTY_BUFFER : cbor.encode(p);
     const SigStructure = [
       'Signature1',

--- a/test/encrypted-tests.js
+++ b/test/encrypted-tests.js
@@ -175,7 +175,7 @@ test('decrypt enc-fail-01', async () => {
   const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-fail-01.json');
   const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
-  await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unknown tag, 995' });
+  await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unexpected cbor tag, \'995\'' });
 });
 
 test('decrypt enc-fail-02', async () => {

--- a/test/enveloped-tests.js
+++ b/test/enveloped-tests.js
@@ -167,7 +167,7 @@ test('decrypt enc-fail-01', async () => {
   const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
 
-  await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unknown tag, 995' });
+  await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unexpected cbor tag, \'995\'' });
 });
 
 test('decrypt enc-fail-02', async () => {


### PR DESCRIPTION
- Add TagsToAlg reverse mapping and shared helpers (getAlgorithm,
  encodeProtected, validateMessage) to common.js, eliminating
  duplicated algorithm mappings and boilerplate across modules
- Extract ECDH key agreement logic from encrypt.js into lib/ecdh.js
  with EC public key on-curve validation
- Add EC public key validation in sign.js doVerify() to prevent
  invalid curve attacks
- Normalize tag error message format across sign/mac/encrypt modules
- Refactor sign.js, mac.js, encrypt.js to use shared helpers

https://claude.ai/code/session_01515txt8zVR5EcNmmKexZqo