### PR TITLE
Remove unnecessary deps and update all to latest

### DIFF
--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -5,7 +5,7 @@
 const cbor = require('cbor');
 const crypto = require('crypto');
 const common = require('./common');
-const HKDF = require('node-hkdf-sync');
+const { hkdfSync } = require('crypto');
 
 const Tagged = cbor.Tagged;
 
@@ -303,8 +303,7 @@ exports.create = async function (headers, payload, recipients, options) {
       // Derive the CEK from the shared secret via HKDF.
       const context = createContext(rp, alg, partyUNonce);
       const nrBytes = keyLength[alg];
-      const hkdf = new HKDF(HKDFAlg[recipients[0].p.alg], undefined, ikm);
-      key = hkdf.derive(context, nrBytes);
+      key = Buffer.from(hkdfSync(HKDFAlg[recipients[0].p.alg], ikm, Buffer.alloc(0), context, nrBytes));
 
       // Attach the sender's public key (or nonce) to the recipient unprotected
       // header so the receiver can reproduce the shared secret.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,19 +10,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "aes-cbc-mac": "^1.0.1",
-        "cbor": "^8.1.0",
-        "elliptic": "^6.4.0",
-        "node-hkdf-sync": "^1.0.0",
+        "cbor": "^10.0.12",
+        "elliptic": "^6.6.1",
         "node-rsa": "^1.1.1"
       },
       "devDependencies": {
-        "base64url": "^3.0.1",
-        "jsonfile": "^2.4.0",
-        "jwk-to-pem": "^2.0.5",
-        "live-server": "*",
+        "jwk-to-pem": "^2.0.7",
+        "live-server": "^1.2.2",
         "npm-run-all": "*",
-        "nyc": "^15.1.0",
-        "semistandard": "^16.0.1",
+        "nyc": "^18.0.0",
+        "semistandard": "^17.0.0",
         "watch": "*"
       },
       "engines": {
@@ -30,47 +27,52 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "version": "7.29.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
-      "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==",
+      "version": "7.29.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.5.tgz",
-      "integrity": "sha512-RN/AwP2DJmQTZSfiDaD+JQQ/J99KsIpOCfBE5pL+5jJSt7nI3nYGoAXZu+ffYSQ029NLs2DstZb+eR81uuARgg==",
+      "version": "7.29.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-compilation-targets": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -80,39 +82,118 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-      "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+      "version": "7.29.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.14.5",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-      "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+      "version": "7.28.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.14.5",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
-        "semver": "^6.3.0"
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -121,198 +202,59 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
-      "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-      "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5",
-        "@babel/helper-simple-access": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-      "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.14.5",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
-      "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+      "version": "7.28.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.27.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.5.tgz",
-      "integrity": "sha512-xtcWOuN9VL6nApgVHtq3PPcQv5qFBJzoSZzJ/2c0QK/IP/gxVcoWSNQwFEGvmbQsuS9rhYqjILDGGXcTkA705Q==",
+      "version": "7.29.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.5.tgz",
-      "integrity": "sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==",
+      "version": "7.29.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -321,141 +263,198 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.28.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-      "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+      "version": "7.29.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-      "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+      "version": "7.29.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "type-fest": "^0.20.2"
+        "ms": "^2.1.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=6.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
-      "engines": {
-        "node": ">= 4"
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+    "node_modules/@eslint/eslintrc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "MIT"
     },
-    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "version": "0.13.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.0",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
       }
     },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -484,18 +483,122 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -511,11 +614,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-      "integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==",
+      "version": "8.16.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -525,9 +628,10 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -551,10 +655,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -564,15 +669,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -653,9 +749,10 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -693,91 +790,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-includes/node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-includes/node_modules/has-symbols": {
+    "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-includes/node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-includes/node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -786,26 +807,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-includes/node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-includes/node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -819,15 +839,19 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array.prototype.flat": {
+    "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
-      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -836,32 +860,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.flat/node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -870,79 +882,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.flat/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat/node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat/node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat/node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat/node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
-      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+      "version": "1.3.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -951,100 +920,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.flatmap/node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap/node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap/node_modules/is-regex": {
+    "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap/node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap/node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1078,20 +988,21 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -1103,6 +1014,22 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -1181,11 +1108,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.17",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1293,26 +1224,60 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "node_modules/browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "version": "4.28.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
-        "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "5.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/builtins/-/builtins-5.1.0.tgz",
+      "integrity": "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cache-base": {
@@ -1351,13 +1316,50 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.9",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1365,32 +1367,45 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001237",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
-      "integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==",
+      "version": "1.0.30001787",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/cbor": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
-      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "version": "10.0.12",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/cbor/-/cbor-10.0.12.tgz",
+      "integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
+      "license": "MIT",
       "dependencies": {
-        "nofilter": "^3.1.0"
+        "nofilter": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.19"
+        "node": ">=20"
       }
     },
     "node_modules/chalk": {
@@ -1505,11 +1520,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "node_modules/colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -1560,19 +1579,11 @@
       "dev": true
     },
     "node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/convert-source-map/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
@@ -1590,10 +1601,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1648,6 +1660,60 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -1691,9 +1757,10 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.0",
@@ -1716,16 +1783,40 @@
         "node": ">=8"
       }
     },
-    "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-property": {
@@ -1798,14 +1889,30 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer": {
@@ -1821,15 +1928,17 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.752",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
-      "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A==",
-      "dev": true
+      "version": "1.5.334",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -1839,11 +1948,6 @@
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/elliptic/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1860,18 +1964,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1882,27 +1974,66 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+      "version": "1.24.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "is-callable": "^1.2.3",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
-        "object-inspect": "^1.10.3",
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1911,27 +2042,106 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-abstract/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "version": "1.3.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1947,10 +2157,11 @@
       "dev": true
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1971,80 +2182,80 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "version": "8.57.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.3",
-        "@humanwhocodes/config-array": "^0.5.0",
-        "ajv": "^6.10.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
+        "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.1.2",
-        "globals": "^13.6.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
-        "strip-ansi": "^6.0.0",
-        "strip-json-comments": "^3.1.0",
-        "table": "^6.0.9",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-config-semistandard": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-16.0.0.tgz",
-      "integrity": "sha512-oD8QOo4mSInRJhQb3Zi6L8HebwZaB6SI3A+NNrPdVN0nN1K45L5pXK3joY+ksWDlT3ew/M+fJk2tuMCjIpjRzQ==",
+      "version": "17.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-config-semistandard/-/eslint-config-semistandard-17.0.0.tgz",
+      "integrity": "sha512-tLi0JYmfiiJgtmRhoES55tENatR7y/5aXOh6cBeW+qjzl1+WwyV0arDqR65XN3/xrPZt+/1EG+xNLknV/0jWsQ==",
       "dev": true,
+      "license": "ISC",
       "peerDependencies": {
-        "eslint": ">=7.12.1",
-        "eslint-config-standard": ">=16.0.3",
-        "eslint-plugin-import": ">=2.22.1",
-        "eslint-plugin-node": ">=11.1.0",
-        "eslint-plugin-promise": ">=4.2.1"
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0"
       }
     },
     "node_modules/eslint-config-standard": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
-      "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
+      "version": "17.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
       "dev": true,
       "funding": [
         {
@@ -2060,17 +2271,18 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
-        "eslint": "^7.12.1",
-        "eslint-plugin-import": "^2.22.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^4.2.1 || ^5.0.0"
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0"
       }
     },
     "node_modules/eslint-config-standard-jsx": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-10.0.0.tgz",
-      "integrity": "sha512-hLeA2f5e06W1xyr/93/QJulN/rLbUVUmqTlexv9PRKHFwEC9ffJcH2LvJhMoEqYQBEYafedgGZXH2W8NUpt5lA==",
+      "version": "11.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
       "dev": true,
       "funding": [
         {
@@ -2086,150 +2298,92 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
-        "eslint": "^7.12.1",
-        "eslint-plugin-react": "^7.21.5"
+        "eslint": "^8.8.0",
+        "eslint-plugin-react": "^7.28.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "version": "0.3.10",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "2.0.0-next.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
-      "integrity": "sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==",
+      "version": "2.12.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "debug": "^3.2.7",
-        "find-up": "^2.1.0",
-        "pkg-dir": "^2.0.0"
+        "debug": "^3.2.7"
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-module-utils/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "version": "4.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
@@ -2244,194 +2398,12 @@
         "eslint": ">=4.19.1"
       }
     },
-    "node_modules/eslint-plugin-import": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
-      "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
-      "dev": true,
-      "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.1",
-        "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
-        "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.11.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "node_modules/eslint-plugin-import/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
-      "dev": true,
-      "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-plugin-promise": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
-      "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
-      "dev": true,
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
-      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
-      "dev": true,
-      "dependencies": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flatmap": "^1.2.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "object.entries": "^1.1.2",
-        "object.fromentries": "^2.0.2",
-        "object.values": "^1.1.1",
-        "prop-types": "^15.7.2",
-        "resolve": "^1.18.1",
-        "string.prototype.matchall": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -2442,38 +2414,304 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+    "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "15.7.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/eslint/node_modules/@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.6.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
+      "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.10.4"
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2484,11 +2722,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2502,9 +2748,10 @@
     },
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2514,15 +2761,52 @@
     },
     "node_modules/eslint/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -2531,73 +2815,79 @@
       }
     },
     "node_modules/eslint/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=10.13.0"
       }
     },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/eslint/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
-        "semver": "bin/semver.js"
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/eslint/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -2606,38 +2896,21 @@
       }
     },
     "node_modules/espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "9.6.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^7.4.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/espree/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -2654,10 +2927,11 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.7.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -2665,20 +2939,12 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2686,29 +2952,22 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2911,31 +3170,36 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-      "engines": {
-        "node": "> 0.1.90"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
@@ -2951,9 +3215,10 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -3059,12 +3324,14 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.2.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -3072,10 +3339,27 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -3087,16 +3371,33 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "version": "3.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fragment-cache": {
@@ -3148,9 +3449,10 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "1.2.13",
@@ -3172,22 +3474,62 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3202,24 +3544,23 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.3.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3236,11 +3577,26 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stdin": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/get-stdin/-/get-stdin-8.0.0.tgz",
       "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3249,13 +3605,15 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3274,16 +3632,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -3317,12 +3676,49 @@
       }
     },
     "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "version": "13.24.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -3331,23 +3727,22 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
+      "license": "MIT"
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3361,22 +3756,27 @@
         "node": ">=4"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
-      "engines": {
-        "node": ">= 0.4"
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "dunder-proto": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3385,11 +3785,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3470,6 +3887,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3536,19 +3966,21 @@
       "dev": true
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.3.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3562,9 +3994,10 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -3589,10 +4022,11 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3604,14 +4038,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3642,17 +4077,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "node_modules/is-bigint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3670,12 +4150,14 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
-      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+      "version": "1.2.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3691,10 +4173,11 @@
       "dev": true
     },
     "node_modules/is-callable": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+      "version": "1.2.7",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3703,12 +4186,16 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "version": "2.16.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3739,13 +4226,39 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-descriptor": {
@@ -3789,6 +4302,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3798,11 +4327,32 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3810,11 +4360,25 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3835,10 +4399,15 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
-      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+      "version": "1.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3858,6 +4427,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3871,13 +4450,16 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "version": "1.2.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.2"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3886,11 +4468,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-regex/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3899,10 +4482,17 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "version": "1.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3917,10 +4507,15 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+      "version": "1.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3929,15 +4524,37 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -3946,13 +4563,47 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3998,10 +4649,11 @@
       }
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
       }
@@ -4019,67 +4671,138 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "version": "6.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@babel/core": "^7.7.5",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.7.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "3.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/istanbul-lib-processinfo/-/istanbul-lib-processinfo-3.0.0.tgz",
+      "integrity": "sha512-P7nLXRRlo7Sqinty6lNa7+4o9jBUYGpqtejqCOZKfgXlRoxY/QArflcB86YO500Ahj4pDJEG34JjMRbQgePLnQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "rimraf": "^6.1.3",
+        "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "20 || >=22"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+    "node_modules/istanbul-lib-processinfo/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "aggregate-error": "^3.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -4132,6 +4855,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4152,16 +4893,24 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -4171,24 +4920,24 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -4196,37 +4945,42 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsx-ast-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
-      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
+      "version": "3.3.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "object.assign": "^4.1.2"
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
       },
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/jwk-to-pem": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.5.tgz",
-      "integrity": "sha512-L90jwellhO8jRKYwbssU9ifaMVqajzj3fpRjDKcsDzrslU9syRbFqfkXtT4B89HYAap+xsxNcxgBSB09ig+a7A==",
+      "version": "2.0.7",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/jwk-to-pem/-/jwk-to-pem-2.0.7.tgz",
+      "integrity": "sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "asn1.js": "^5.3.0",
-        "elliptic": "^6.5.4",
+        "elliptic": "^6.6.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -4240,9 +4994,10 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -4252,13 +5007,14 @@
       }
     },
     "node_modules/live-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/live-server/-/live-server-1.2.1.tgz",
-      "integrity": "sha512-Yn2XCVjErTkqnM3FfTmM7/kWy3zP7+cEtC7x6u+wUzlQ+1UW3zEYbbyJrc0jNDwiMDZI0m4a0i3dxlGHVyXczw==",
+      "version": "1.2.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/live-server/-/live-server-1.2.2.tgz",
+      "integrity": "sha512-t28HXLjITRGoMSrCOv4eZ88viHaBVIjKjdI5PO92Vxlu+twbk6aE0t7dVIaz6ZWkjPilYFV6OSdMYl9ybN2B4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^2.0.4",
-        "colors": "latest",
+        "colors": "1.4.0",
         "connect": "^3.6.6",
         "cors": "latest",
         "event-stream": "3.3.4",
@@ -4276,15 +5032,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/live-server/node_modules/colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/live-server/node_modules/cors": {
@@ -4314,15 +5061,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "node_modules/live-server/node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/live-server/node_modules/opn": {
       "version": "6.0.0",
@@ -4414,38 +5152,22 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-dir": {
@@ -4497,6 +5219,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/memorystream": {
@@ -4582,10 +5314,11 @@
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4594,10 +5327,24 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -4701,9 +5448,10 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.2",
@@ -4720,15 +5468,33 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node_modules/node-hkdf-sync": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-hkdf-sync/-/node-hkdf-sync-1.0.0.tgz",
-      "integrity": "sha1-ZX15hkHAA/kQN7aKNZXgW+c22Zo=",
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "vows": "0.5.13"
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
       },
       "engines": {
-        "node": ">= 0.6.5"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/node-preload": {
@@ -4744,10 +5510,11 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.76",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
-      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
-      "dev": true
+      "version": "2.0.37",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-rsa": {
       "version": "1.1.1",
@@ -4837,10 +5604,11 @@
       }
     },
     "node_modules/nyc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+      "version": "18.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/nyc/-/nyc-18.0.0.tgz",
+      "integrity": "sha512-G5UyHinFkB1BxqGTrmZdB6uIYH0+v7ZnVssuflUDi+J+RhKWyAhRT1RCehBSI6jLFLuUUgFDyLt49mUtdO1XeQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.2",
@@ -4849,13 +5617,13 @@
         "decamelize": "^1.2.0",
         "find-cache-dir": "^3.2.0",
         "find-up": "^4.1.0",
-        "foreground-child": "^2.0.0",
+        "foreground-child": "^3.3.0",
         "get-package-type": "^0.1.0",
-        "glob": "^7.1.6",
+        "glob": "^13.0.6",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.0",
-        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-instrument": "^6.0.2",
+        "istanbul-lib-processinfo": "^3.0.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
@@ -4864,17 +5632,17 @@
         "p-map": "^3.0.0",
         "process-on-spawn": "^1.0.0",
         "resolve-from": "^5.0.0",
-        "rimraf": "^3.0.0",
+        "rimraf": "^6.1.3",
         "signal-exit": "^3.0.2",
-        "spawn-wrap": "^2.0.0",
-        "test-exclude": "^6.0.0",
+        "spawn-wrap": "^3.0.0",
+        "test-exclude": "^8.0.0",
         "yargs": "^15.0.2"
       },
       "bin": {
         "nyc": "bin/nyc.js"
       },
       "engines": {
-        "node": ">=8.9"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nyc/node_modules/ansi-styles": {
@@ -4890,6 +5658,29 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/nyc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/nyc/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/nyc/node_modules/camelcase": {
@@ -4930,16 +5721,58 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/nyc/node_modules/p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+    "node_modules/nyc/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "aggregate-error": "^3.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nyc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nyc/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
@@ -5045,10 +5878,14 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+      "version": "1.13.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5075,14 +5912,17 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.7",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -5092,139 +5932,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.assign/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object.entries": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
-      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "version": "1.1.9",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.entries/node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries/node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries/node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries/node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries/node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
-      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "version": "2.0.8",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5233,102 +5967,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.fromentries/node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.fromentries/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.fromentries/node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.fromentries/node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.fromentries/node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.fromentries/node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.pick": {
@@ -5344,116 +5995,20 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "version": "1.2.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values/node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values/node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values/node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values/node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values/node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5481,28 +6036,48 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -5532,6 +6107,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -5556,11 +6144,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -5638,6 +6234,33 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -5668,6 +6291,13 @@
         "through": "~2.3"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pidtree": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
@@ -5682,18 +6312,20 @@
     },
     "node_modules/pify": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/pkg-conf": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/pkg-conf/-/pkg-conf-3.1.0.tgz",
       "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-up": "^3.0.0",
         "load-json-file": "^5.2.0"
@@ -5704,9 +6336,10 @@
     },
     "node_modules/pkg-conf/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -5716,9 +6349,10 @@
     },
     "node_modules/pkg-conf/node_modules/load-json-file": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/load-json-file/-/load-json-file-5.3.0.tgz",
       "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.15",
         "parse-json": "^4.0.0",
@@ -5732,9 +6366,10 @@
     },
     "node_modules/pkg-conf/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -5745,9 +6380,10 @@
     },
     "node_modules/pkg-conf/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -5757,11 +6393,22 @@
     },
     "node_modules/pkg-conf/node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pkg-dir": {
@@ -5785,11 +6432,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -5812,34 +6470,48 @@
         "node": ">=8"
       }
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "version": "15.8.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -5852,9 +6524,10 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",
@@ -5905,6 +6578,29 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5919,13 +6615,18 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.5.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5936,9 +6637,10 @@
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -5991,15 +6693,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -6040,12 +6733,24 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -6055,6 +6760,57 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -6076,6 +6832,30 @@
         }
       ]
     },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -6085,15 +6865,33 @@
         "ret": "~0.1.10"
       }
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semistandard": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-16.0.1.tgz",
-      "integrity": "sha512-ApAJ9fMAIwYuk5xI2HWSCd8s5o5L95abxU4dYl6ovUX6Rcww/7oxtaSuu9wLFL/Gfj/EXx1h6S4itXy5vyL60Q==",
+      "version": "17.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/semistandard/-/semistandard-17.0.0.tgz",
+      "integrity": "sha512-FnZ77h6LpCjIl0S2kf8utBjBxuFfiV+6DbnFDEJuxWP91el+Syp6P/T54KCJbczmQx9vIy/cXpSOuPzofnrUKA==",
       "dev": true,
       "funding": [
         {
@@ -6109,22 +6907,23 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "eslint": "^7.27.0",
-        "eslint-config-semistandard": "16.0.0",
-        "eslint-config-standard": "16.0.3",
-        "eslint-config-standard-jsx": "10.0.0",
-        "eslint-plugin-import": "^2.22.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^5.1.0",
-        "eslint-plugin-react": "~7.21.5",
-        "standard-engine": "^14.0.0"
+        "eslint": "^8.20.0",
+        "eslint-config-semistandard": "^17.0.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.2.4",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.30.1",
+        "standard-engine": "^15.0.0"
       },
       "bin": {
         "semistandard": "bin/cmd.js"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/semver": {
@@ -6202,6 +7001,55 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -6263,14 +7111,76 @@
       "dev": true
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6461,15 +7371,17 @@
       "dev": true
     },
     "node_modules/spawn-wrap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "version": "3.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/spawn-wrap/-/spawn-wrap-3.0.0.tgz",
+      "integrity": "sha512-z+s5vv4KzFPJVddGab0xX2n7kQPGMdNUX5l9T8EJqsXdKTWpcxmAqWHpsgHEXoC1taGBCc7b79bi62M5kdbrxQ==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
+        "cross-spawn": "^7.0.6",
         "foreground-child": "^2.0.0",
         "is-windows": "^1.0.2",
         "make-dir": "^3.0.0",
-        "rimraf": "^3.0.0",
+        "rimraf": "^6.1.3",
         "signal-exit": "^3.0.2",
         "which": "^2.0.1"
       },
@@ -6477,11 +7389,103 @@
         "node": ">=8"
       }
     },
+    "node_modules/spawn-wrap/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/spawn-wrap/node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -6555,9 +7559,9 @@
       "dev": true
     },
     "node_modules/standard-engine": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-14.0.1.tgz",
-      "integrity": "sha512-7FEzDwmHDOGva7r9ifOzD3BGdTbA7ujJ50afLVdW/tK14zQEptJjbFuUfn50irqdHDcTbNh0DTIoMPynMCXb0Q==",
+      "version": "15.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/standard-engine/-/standard-engine-15.1.0.tgz",
+      "integrity": "sha512-VHysfoyxFu/ukT+9v49d4BRXIokFRZuH3z1VRxzFArZdjSCFpro6rEIU3ji7e4AoAtuSfKBkiOmsrDqKW5ZSRw==",
       "dev": true,
       "funding": [
         {
@@ -6573,14 +7577,15 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "get-stdin": "^8.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "pkg-conf": "^3.1.0",
         "xdg-basedir": "^4.0.0"
       },
       "engines": {
-        "node": ">=8.10"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/static-extend": {
@@ -6615,6 +7620,20 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/stream-combiner": {
@@ -6656,118 +7675,29 @@
       }
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
-      "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+      "version": "4.0.12",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.3.1",
-        "side-channel": "^1.0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.matchall/node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.matchall/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.matchall/node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.matchall/node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.matchall/node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.matchall/node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6789,39 +7719,84 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.8",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -6834,6 +7809,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -6857,154 +7845,103 @@
         "node": ">=8"
       }
     },
-    "node_modules/table": {
-      "version": "6.7.5",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
-      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/table/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/table/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/table/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/table/node_modules/json-schema-traverse": {
+    "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/table/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/table/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/table/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "version": "8.0.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-object-path": {
       "version": "0.3.0",
@@ -7068,22 +8005,24 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
-      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "version": "3.15.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -7093,9 +8032,10 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -7104,12 +8044,94 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "version": "0.20.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -7122,25 +8144,17 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
-        "which-boxed-primitive": "^1.0.2"
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/unbox-primitive/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7236,11 +8250,43 @@
         "yarn": "*"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7286,12 +8332,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -7309,20 +8349,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vows": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/vows/-/vows-0.5.13.tgz",
-      "integrity": "sha1-9v2e6cNtPyC9ZoBFXP+AkMSynN4=",
-      "dependencies": {
-        "eyes": ">=0.1.6"
-      },
-      "bin": {
-        "vows": "bin/vows"
-      },
-      "engines": {
-        "node": ">=0.2.6"
       }
     },
     "node_modules/watch": {
@@ -7377,26 +8403,18 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "version": "1.1.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-boxed-primitive/node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7404,13 +8422,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-boxed-primitive/node_modules/is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7425,20 +8482,44 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -7454,18 +8535,26 @@
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,19 +42,16 @@
   "homepage": "https://github.com/erdtman/cose-js#readme",
   "dependencies": {
     "aes-cbc-mac": "^1.0.1",
-    "cbor": "^8.1.0",
-    "elliptic": "^6.4.0",
-    "node-hkdf-sync": "^1.0.0",
+    "cbor": "^10.0.12",
+    "elliptic": "^6.6.1",
     "node-rsa": "^1.1.1"
   },
   "devDependencies": {
-    "base64url": "^3.0.1",
-    "jsonfile": "^2.4.0",
-    "jwk-to-pem": "^2.0.5",
-    "live-server": "*",
+    "jwk-to-pem": "^2.0.7",
+    "live-server": "^1.2.2",
     "npm-run-all": "*",
-    "nyc": "^15.1.0",
-    "semistandard": "^16.0.1",
+    "nyc": "^18.0.0",
+    "semistandard": "^17.0.0",
     "watch": "*"
   },
   "engines": {

--- a/test/aes-ccm-examples.js
+++ b/test/aes-ccm-examples.js
@@ -5,10 +5,8 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 function randomSource (bytes) {
   if (bytes === 12) {
@@ -23,13 +21,13 @@ function randomSource (bytes) {
 }
 
 test('create aes-ccm-enc-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-01.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-01.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -46,13 +44,13 @@ test('create aes-ccm-enc-01', async () => {
 });
 
 test('create aes-ccm-enc-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-02.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-02.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -69,13 +67,13 @@ test('create aes-ccm-enc-02', async () => {
 });
 
 test('create aes-ccm-enc-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-03.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-03.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -93,13 +91,13 @@ test('create aes-ccm-enc-03', async () => {
 });
 
 test('create aes-ccm-enc-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-04.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-04.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -117,13 +115,13 @@ test('create aes-ccm-enc-04', async () => {
 });
 
 test('create aes-ccm-enc-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-05.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-05.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -141,13 +139,13 @@ test('create aes-ccm-enc-05', async () => {
 });
 
 test('create aes-ccm-enc-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-06.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-06.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -165,13 +163,13 @@ test('create aes-ccm-enc-06', async () => {
 });
 
 test('create aes-ccm-enc-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-07.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-07.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -189,13 +187,13 @@ test('create aes-ccm-enc-07', async () => {
 });
 
 test('create aes-ccm-enc-08', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-08.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-08.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -213,9 +211,9 @@ test('create aes-ccm-enc-08', async () => {
 });
 
 test('decrypt aes-ccm-enc-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-01.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-01.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -224,9 +222,9 @@ test('decrypt aes-ccm-enc-01', async () => {
 });
 
 test('decrypt aes-ccm-enc-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-02.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-02.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -235,9 +233,9 @@ test('decrypt aes-ccm-enc-02', async () => {
 });
 
 test('decrypt aes-ccm-enc-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-03.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-03.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -246,9 +244,9 @@ test('decrypt aes-ccm-enc-03', async () => {
 });
 
 test('decrypt aes-ccm-enc-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-04.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-04.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -257,9 +255,9 @@ test('decrypt aes-ccm-enc-04', async () => {
 });
 
 test('decrypt aes-ccm-enc-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-05.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-05.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -268,9 +266,9 @@ test('decrypt aes-ccm-enc-05', async () => {
 });
 
 test('decrypt aes-ccm-enc-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-06.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-06.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -279,9 +277,9 @@ test('decrypt aes-ccm-enc-06', async () => {
 });
 
 test('decrypt aes-ccm-enc-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-07.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-07.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -290,9 +288,9 @@ test('decrypt aes-ccm-enc-07', async () => {
 });
 
 test('decrypt aes-ccm-enc-08', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-enc-08.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-enc-08.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -301,13 +299,13 @@ test('decrypt aes-ccm-enc-08', async () => {
 });
 
 test('create aes-ccm-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-01.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -323,13 +321,13 @@ test('create aes-ccm-01', async () => {
 });
 
 test('create aes-ccm-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-02.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-02.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -347,13 +345,13 @@ test('create aes-ccm-02', async () => {
 });
 
 test('create aes-ccm-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-03.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-03.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -371,13 +369,13 @@ test('create aes-ccm-03', async () => {
 });
 
 test('create aes-ccm-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-04.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-04.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -395,13 +393,13 @@ test('create aes-ccm-04', async () => {
 });
 
 test('create aes-ccm-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-05.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-05.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -419,13 +417,13 @@ test('create aes-ccm-05', async () => {
 });
 
 test('create aes-ccm-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-06.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-06.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -443,13 +441,13 @@ test('create aes-ccm-06', async () => {
 });
 
 test('create aes-ccm-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-07.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-07.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -467,13 +465,13 @@ test('create aes-ccm-07', async () => {
 });
 
 test('create aes-ccm-08', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-08.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-08.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -491,9 +489,9 @@ test('create aes-ccm-08', async () => {
 });
 
 test('decrypt aes-ccm-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-01.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-01.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -502,9 +500,9 @@ test('decrypt aes-ccm-01', async () => {
 });
 
 test('decrypt aes-ccm-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-02.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-02.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -513,9 +511,9 @@ test('decrypt aes-ccm-02', async () => {
 });
 
 test('decrypt aes-ccm-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-03.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-03.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -524,9 +522,9 @@ test('decrypt aes-ccm-03', async () => {
 });
 
 test('decrypt aes-ccm-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-04.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-04.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -535,9 +533,9 @@ test('decrypt aes-ccm-04', async () => {
 });
 
 test('decrypt aes-ccm-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-05.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-05.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -546,9 +544,9 @@ test('decrypt aes-ccm-05', async () => {
 });
 
 test('decrypt aes-ccm-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-06.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-06.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -557,9 +555,9 @@ test('decrypt aes-ccm-06', async () => {
 });
 
 test('decrypt aes-ccm-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-07.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-07.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -568,9 +566,9 @@ test('decrypt aes-ccm-07', async () => {
 });
 
 test('decrypt aes-ccm-08', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-ccm-examples/aes-ccm-08.json');
+  const example = loadExample('test/Examples/aes-ccm-examples/aes-ccm-08.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));

--- a/test/aes-gcm-examples.js
+++ b/test/aes-gcm-examples.js
@@ -5,10 +5,8 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 function randomSource (bytes) {
   if (bytes === 12) {
@@ -19,13 +17,13 @@ function randomSource (bytes) {
 }
 
 test('create aes-gcm-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-01.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipients = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -42,13 +40,13 @@ test('create aes-gcm-01', async () => {
 });
 
 test('create aes-gcm-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-02.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-02.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipients = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -65,13 +63,13 @@ test('create aes-gcm-02', async () => {
 });
 
 test('create aes-gcm-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-03.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-03.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipients = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -90,13 +88,13 @@ test('create aes-gcm-03', async () => {
 // aes-gcm-04 is an error example and cannot be recreated
 
 test('create aes-gcm-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-05.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-05.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipients = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -121,9 +119,9 @@ test('create aes-gcm-05', async () => {
 });
 
 test('decrypt aes-gcm-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-01.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-01.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -132,9 +130,9 @@ test('decrypt aes-gcm-01', async () => {
 });
 
 test('decrypt aes-gcm-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-02.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-02.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -143,9 +141,9 @@ test('decrypt aes-gcm-02', async () => {
 });
 
 test('decrypt aes-gcm-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-03.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-03.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -154,16 +152,16 @@ test('decrypt aes-gcm-03', async () => {
 });
 
 test('decrypt aes-gcm-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-04.json');
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-04.json');
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unsupported state or unable to authenticate data' });
 });
 
 test('decrypt aes-gcm-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-05.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-05.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const contextIv = Buffer.from(example.input.enveloped.unsent.IV_hex, 'hex');
   contextIv[10] = 0;
@@ -176,13 +174,13 @@ test('decrypt aes-gcm-05', async () => {
 });
 
 test('create aes-gcm-enc-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-enc-01.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-enc-01.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -199,13 +197,13 @@ test('create aes-gcm-enc-01', async () => {
 });
 
 test('create aes-gcm-enc-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-enc-02.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-enc-02.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -222,13 +220,13 @@ test('create aes-gcm-enc-02', async () => {
 });
 
 test('create aes-gcm-enc-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-enc-03.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-enc-03.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -247,9 +245,9 @@ test('create aes-gcm-enc-03', async () => {
 // create aes-gcm-enc-04 is an error example and cannot be recreated
 
 test('decrypt aes-gcm-enc-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-enc-01.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-enc-01.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -258,9 +256,9 @@ test('decrypt aes-gcm-enc-01', async () => {
 });
 
 test('decrypt aes-gcm-enc-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-enc-02.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-enc-02.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -269,9 +267,9 @@ test('decrypt aes-gcm-enc-02', async () => {
 });
 
 test('decrypt aes-gcm-enc-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-enc-03.json');
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-enc-03.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -280,8 +278,8 @@ test('decrypt aes-gcm-enc-03', async () => {
 });
 
 test('decrypt aes-gcm-enc-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/aes-gcm-examples/aes-gcm-enc-04.json');
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const example = loadExample('test/Examples/aes-gcm-examples/aes-gcm-enc-04.json');
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unsupported state or unable to authenticate data' });
 });

--- a/test/cbc-mac-examples.js
+++ b/test/cbc-mac-examples.js
@@ -5,16 +5,14 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 test('create cbc-mac-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-01.json');
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-01.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p };
@@ -29,10 +27,10 @@ test('create cbc-mac-01', async () => {
 });
 
 test('create cbc-mac-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-02.json');
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-02.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p };
@@ -48,10 +46,10 @@ test('create cbc-mac-02', async () => {
 });
 
 test('create cbc-mac-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-03.json');
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-03.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p };
@@ -67,10 +65,10 @@ test('create cbc-mac-03', async () => {
 });
 
 test('create cbc-mac-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-04.json');
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-04.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p };
@@ -86,9 +84,9 @@ test('create cbc-mac-04', async () => {
 });
 
 test('create cbc-mac-enc-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-enc-01.json');
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-enc-01.json');
   const p = example.input.mac0.protected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p };
@@ -105,9 +103,9 @@ test('create cbc-mac-enc-01', async () => {
 });
 
 test('create cbc-mac-enc-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-enc-02.json');
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-enc-02.json');
   const p = example.input.mac0.protected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p };
@@ -124,9 +122,9 @@ test('create cbc-mac-enc-02', async () => {
 });
 
 test('create cbc-mac-enc-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-enc-03.json');
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-enc-03.json');
   const p = example.input.mac0.protected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p };
@@ -143,9 +141,9 @@ test('create cbc-mac-enc-03', async () => {
 });
 
 test('create cbc-mac-enc-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-enc-04.json');
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-enc-04.json');
   const p = example.input.mac0.protected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p };
@@ -162,8 +160,8 @@ test('create cbc-mac-enc-04', async () => {
 });
 
 test('verify cbc-mac-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-01.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-01.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -173,8 +171,8 @@ test('verify cbc-mac-01', async () => {
 });
 
 test('verify cbc-mac-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-02.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-02.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -184,8 +182,8 @@ test('verify cbc-mac-02', async () => {
 });
 
 test('verify cbc-mac-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-03.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-03.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -195,8 +193,8 @@ test('verify cbc-mac-03', async () => {
 });
 
 test('verify cbc-mac-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-04.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-04.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -206,8 +204,8 @@ test('verify cbc-mac-04', async () => {
 });
 
 test('verify cbc-mac-enc-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-enc-02.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-enc-02.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -217,8 +215,8 @@ test('verify cbc-mac-enc-01', async () => {
 });
 
 test('verify cbc-mac-enc-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-enc-02.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-enc-02.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -228,8 +226,8 @@ test('verify cbc-mac-enc-02', async () => {
 });
 
 test('verify cbc-mac-enc-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-enc-03.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-enc-03.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -239,8 +237,8 @@ test('verify cbc-mac-enc-03', async () => {
 });
 
 test('verify cbc-mac-enc-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/cbc-mac-examples/cbc-mac-enc-04.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/cbc-mac-examples/cbc-mac-enc-04.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);

--- a/test/ecdh-direct-examples.js
+++ b/test/ecdh-direct-examples.js
@@ -5,10 +5,8 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 function randomSource (bytes) {
   if (bytes === 12) {
@@ -19,7 +17,7 @@ function randomSource (bytes) {
 }
 
 test('create p256-hkdf-256-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p256-hkdf-256-01.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p256-hkdf-256-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -29,9 +27,9 @@ test('create p256-hkdf-256-01', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected
@@ -51,7 +49,7 @@ test('create p256-hkdf-256-01', async () => {
 });
 
 test('create p256-hkdf-256-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p256-hkdf-256-02.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p256-hkdf-256-02.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -61,9 +59,9 @@ test('create p256-hkdf-256-02', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected
@@ -85,7 +83,7 @@ test('create p256-hkdf-256-02', async () => {
 // create p256-hkdf-256-03
 
 test('create p256-hkdf-512-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p256-hkdf-512-01.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p256-hkdf-512-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -95,9 +93,9 @@ test('create p256-hkdf-512-01', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected
@@ -117,7 +115,7 @@ test('create p256-hkdf-512-01', async () => {
 });
 
 test('create p256-hkdf-512-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p256-hkdf-512-02.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p256-hkdf-512-02.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -127,9 +125,9 @@ test('create p256-hkdf-512-02', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected
@@ -157,7 +155,7 @@ test('create p256-hkdf-512-02', async () => {
 // create p256-hkdf-512-03
 
 test('create p256-ss-hkdf-256-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p256-ss-hkdf-256-01.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p256-ss-hkdf-256-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -167,16 +165,16 @@ test('create p256-ss-hkdf-256-01', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     sender: {
       kty: example.input.enveloped.recipients[0].sender_key.kty,
       crv: example.input.enveloped.recipients[0].sender_key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].sender_key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].sender_key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].sender_key.d)
+      x: b64url(example.input.enveloped.recipients[0].sender_key.x),
+      y: b64url(example.input.enveloped.recipients[0].sender_key.y),
+      d: b64url(example.input.enveloped.recipients[0].sender_key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected
@@ -212,7 +210,7 @@ test('create p256-ss-hkdf-256-01', async () => {
 // create p256-ss-hkdf-512-03
 
 test('create p521-hkdf-256-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p521-hkdf-256-01.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p521-hkdf-256-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -222,9 +220,9 @@ test('create p521-hkdf-256-01', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected
@@ -250,7 +248,7 @@ test('create p521-hkdf-256-01', async () => {
 });
 
 test('create p521-hkdf-256-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p521-hkdf-256-02.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p521-hkdf-256-02.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -260,9 +258,9 @@ test('create p521-hkdf-256-02', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected
@@ -290,7 +288,7 @@ test('create p521-hkdf-256-02', async () => {
 // create p521-hkdf-256-03
 
 test('create p521-hkdf-512-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p521-hkdf-512-01.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p521-hkdf-512-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -300,9 +298,9 @@ test('create p521-hkdf-512-01', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected
@@ -328,7 +326,7 @@ test('create p521-hkdf-512-01', async () => {
 });
 
 test('create p521-hkdf-512-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdh-direct-examples/p521-hkdf-512-02.json');
+  const example = loadExample('test/Examples/ecdh-direct-examples/p521-hkdf-512-02.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -338,9 +336,9 @@ test('create p521-hkdf-512-02', async () => {
       kty: example.input.enveloped.recipients[0].key.kty,
       kid: example.input.enveloped.recipients[0].key.kid,
       crv: example.input.enveloped.recipients[0].key.crv,
-      x: base64url.toBuffer(example.input.enveloped.recipients[0].key.x),
-      y: base64url.toBuffer(example.input.enveloped.recipients[0].key.y),
-      d: base64url.toBuffer(example.input.enveloped.recipients[0].key.d)
+      x: b64url(example.input.enveloped.recipients[0].key.x),
+      y: b64url(example.input.enveloped.recipients[0].key.y),
+      d: b64url(example.input.enveloped.recipients[0].key.d)
     },
     p: example.input.enveloped.recipients[0].protected,
     u: example.input.enveloped.recipients[0].unprotected

--- a/test/encrypted-tests.js
+++ b/test/encrypted-tests.js
@@ -5,10 +5,8 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 function randomSource (bytes) {
   if (bytes === 12) {
@@ -19,13 +17,13 @@ function randomSource (bytes) {
 }
 
 test('create aes-gcm-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/aes-gcm-01.json');
+  const example = loadExample('test/Examples/encrypted-tests/aes-gcm-01.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -43,13 +41,13 @@ test('create aes-gcm-01', async () => {
 });
 
 test('create enc-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-pass-01.json');
+  const example = loadExample('test/Examples/encrypted-tests/enc-pass-01.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -66,14 +64,14 @@ test('create enc-pass-01', async () => {
 });
 
 test('create enc-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-pass-02.json');
+  const example = loadExample('test/Examples/encrypted-tests/enc-pass-02.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
   const external = Buffer.from(example.input.encrypted.external, 'hex');
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -93,13 +91,13 @@ test('create enc-pass-02', async () => {
 });
 
 test('create enc-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-pass-03.json');
+  const example = loadExample('test/Examples/encrypted-tests/enc-pass-03.json');
   const p = example.input.encrypted.protected;
   const u = example.input.encrypted.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipient = {
-    key: base64url.toBuffer(example.input.encrypted.recipients[0].key.k),
+    key: b64url(example.input.encrypted.recipients[0].key.k),
     u: example.input.encrypted.recipients[0].unprotected
   };
 
@@ -119,9 +117,9 @@ test('create enc-pass-03', async () => {
 });
 
 test('decrypt aes-gcm-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/aes-gcm-01.json');
+  const example = loadExample('test/Examples/encrypted-tests/aes-gcm-01.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
@@ -131,9 +129,9 @@ test('decrypt aes-gcm-01', async () => {
 });
 
 test('decrypt enc-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-pass-01.json');
+  const example = loadExample('test/Examples/encrypted-tests/enc-pass-01.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
@@ -143,9 +141,9 @@ test('decrypt enc-pass-01', async () => {
 });
 
 test('decrypt enc-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-pass-02.json');
+  const example = loadExample('test/Examples/encrypted-tests/enc-pass-02.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const options = {
     externalAAD: Buffer.from(example.input.encrypted.external, 'hex')
   };
@@ -158,9 +156,9 @@ test('decrypt enc-pass-02', async () => {
 });
 
 test('decrypt enc-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-pass-03.json');
+  const example = loadExample('test/Examples/encrypted-tests/enc-pass-03.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const options = {
     defaultType: cose.encrypt.Encrypt0Tag
   };
@@ -172,43 +170,43 @@ test('decrypt enc-pass-03', async () => {
 });
 
 test('decrypt enc-fail-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-fail-01.json');
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const example = loadExample('test/Examples/encrypted-tests/enc-fail-01.json');
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unknown tag, 995' });
 });
 
 test('decrypt enc-fail-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-fail-02.json');
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const example = loadExample('test/Examples/encrypted-tests/enc-fail-02.json');
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unsupported state or unable to authenticate data' });
 });
 
 test('decrypt enc-fail-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-fail-03.json');
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const example = loadExample('test/Examples/encrypted-tests/enc-fail-03.json');
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unknown or unsupported algorithm -999' });
 });
 
 test('decrypt enc-fail-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-fail-04.json');
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const example = loadExample('test/Examples/encrypted-tests/enc-fail-04.json');
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unknown or unsupported algorithm Unknown' });
 });
 
 test('decrypt enc-fail-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-fail-06.json');
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const example = loadExample('test/Examples/encrypted-tests/enc-fail-06.json');
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unsupported state or unable to authenticate data' });
 });
 
 test('decrypt enc-fail-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/encrypted-tests/enc-fail-07.json');
-  const key = base64url.toBuffer(example.input.encrypted.recipients[0].key.k);
+  const example = loadExample('test/Examples/encrypted-tests/enc-fail-07.json');
+  const key = b64url(example.input.encrypted.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unsupported state or unable to authenticate data' });
 });

--- a/test/enveloped-tests.js
+++ b/test/enveloped-tests.js
@@ -5,10 +5,8 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 function randomSource (bytes) {
   if (bytes === 12) {
@@ -19,13 +17,13 @@ function randomSource (bytes) {
 }
 
 test('create aes-gcm-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/aes-gcm-01.json');
+  const example = loadExample('test/Examples/enveloped-tests/aes-gcm-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipients = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -42,13 +40,13 @@ test('create aes-gcm-01', async () => {
 });
 
 test('create env-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-pass-01.json');
+  const example = loadExample('test/Examples/enveloped-tests/env-pass-01.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipients = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -66,13 +64,13 @@ test('create env-pass-01', async () => {
 });
 
 test('create env-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-pass-02.json');
+  const example = loadExample('test/Examples/enveloped-tests/env-pass-02.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipients = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -90,13 +88,13 @@ test('create env-pass-02', async () => {
 });
 
 test('create env-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-pass-03.json');
+  const example = loadExample('test/Examples/enveloped-tests/env-pass-03.json');
   const p = example.input.enveloped.protected;
   const u = example.input.enveloped.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipients = [{
-    key: base64url.toBuffer(example.input.enveloped.recipients[0].key.k),
+    key: b64url(example.input.enveloped.recipients[0].key.k),
     u: example.input.enveloped.recipients[0].unprotected
   }];
 
@@ -115,9 +113,9 @@ test('create env-pass-03', async () => {
 });
 
 test('decrypt aes-gcm-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/aes-gcm-01.json');
+  const example = loadExample('test/Examples/enveloped-tests/aes-gcm-01.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
@@ -127,9 +125,9 @@ test('decrypt aes-gcm-01', async () => {
 });
 
 test('decrypt enc-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-pass-01.json');
+  const example = loadExample('test/Examples/enveloped-tests/env-pass-01.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -138,9 +136,9 @@ test('decrypt enc-pass-01', async () => {
 });
 
 test('decrypt enc-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-pass-02.json');
+  const example = loadExample('test/Examples/enveloped-tests/env-pass-02.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const options = {
     externalAAD: Buffer.from(example.input.enveloped.external, 'hex')
   };
@@ -152,9 +150,9 @@ test('decrypt enc-pass-02', async () => {
 });
 
 test('decrypt enc-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-pass-03.json');
+  const example = loadExample('test/Examples/enveloped-tests/env-pass-03.json');
   const plaintext = example.input.plaintext;
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.encrypt.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -163,48 +161,48 @@ test('decrypt enc-pass-03', async () => {
 });
 
 test('decrypt enc-fail-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-fail-01.json');
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const example = loadExample('test/Examples/enveloped-tests/env-fail-01.json');
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unknown tag, 995' });
 });
 
 test('decrypt enc-fail-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-fail-02.json');
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const example = loadExample('test/Examples/enveloped-tests/env-fail-02.json');
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unsupported state or unable to authenticate data' });
 });
 
 test('decrypt enc-fail-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-fail-03.json');
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const example = loadExample('test/Examples/enveloped-tests/env-fail-03.json');
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unknown or unsupported algorithm -999' });
 });
 
 test('decrypt enc-fail-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-fail-04.json');
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const example = loadExample('test/Examples/enveloped-tests/env-fail-04.json');
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unknown or unsupported algorithm Unknown' });
 });
 
 test('decrypt enc-fail-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-fail-06.json');
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const example = loadExample('test/Examples/enveloped-tests/env-fail-06.json');
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unsupported state or unable to authenticate data' });
 });
 
 test('decrypt enc-fail-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/enveloped-tests/env-fail-07.json');
-  const key = base64url.toBuffer(example.input.enveloped.recipients[0].key.k);
+  const example = loadExample('test/Examples/enveloped-tests/env-fail-07.json');
+  const key = b64url(example.input.enveloped.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.encrypt.read(data, key), { message: 'Unsupported state or unable to authenticate data' });

--- a/test/hmac-examples.js
+++ b/test/hmac-examples.js
@@ -5,16 +5,14 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 test('create HMac-enc-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-01.json');
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-01.json');
   const p = example.input.mac0.protected;
   const u = example.input.mac0.unprotected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const header = { p: p, u: u };
   const recipeient = { key: key };
@@ -27,10 +25,10 @@ test('create HMac-enc-01', async () => {
 });
 
 test('create HMac-enc-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-02.json');
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-02.json');
   const p = example.input.mac0.protected;
   const u = example.input.mac0.unprotected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const header = { p: p, u: u };
   const recipient = { key: key };
@@ -43,10 +41,10 @@ test('create HMac-enc-02', async () => {
 });
 
 test('create HMac-enc-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-03.json');
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-03.json');
   const p = example.input.mac0.protected;
   const u = example.input.mac0.unprotected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const header = { p: p, u: u };
   const recipient = { key: key };
@@ -61,10 +59,10 @@ test('create HMac-enc-03', async () => {
 // HMac-enc-04 is a negative test and cannot be recreated
 
 test('create HMac-enc-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-05.json');
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-05.json');
   const p = example.input.mac0.protected;
   const u = example.input.mac0.unprotected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const header = { p: p, u: u };
   const recipeint = { key: key };
@@ -77,8 +75,8 @@ test('create HMac-enc-05', async () => {
 });
 
 test('verify HMac-enc-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-01.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-01.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -87,8 +85,8 @@ test('verify HMac-enc-01', async () => {
 });
 
 test('verify HMac-enc-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-02.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-02.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -98,8 +96,8 @@ test('verify HMac-enc-02', async () => {
 });
 
 test('verify HMac-enc-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-03.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-03.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -108,15 +106,15 @@ test('verify HMac-enc-03', async () => {
 });
 
 test('verify HMac-enc-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-04.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-04.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Tag mismatch' });
 });
 
 test('verify HMac-enc-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-enc-05.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-enc-05.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -125,10 +123,10 @@ test('verify HMac-enc-05', async () => {
 });
 
 test('create HMac-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-01.json');
+  const example = loadExample('test/Examples/hmac-examples/HMac-01.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const recipents = [{ key: key, u: u }];
   const header = { p: p };
@@ -141,10 +139,10 @@ test('create HMac-01', async () => {
 });
 
 test('create HMac-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-02.json');
+  const example = loadExample('test/Examples/hmac-examples/HMac-02.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const recipents = [{ key: key, u: u }];
   const header = { p: p };
@@ -157,10 +155,10 @@ test('create HMac-02', async () => {
 });
 
 test('create HMac-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-03.json');
+  const example = loadExample('test/Examples/hmac-examples/HMac-03.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const recipents = [{ key: key, u: u }];
   const header = { p: p };
@@ -175,10 +173,10 @@ test('create HMac-03', async () => {
 // HMac-04 is a negative test and cannot be recreated
 
 test('create HMac-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-05.json');
+  const example = loadExample('test/Examples/hmac-examples/HMac-05.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const recipents = [{ key: key, u: u }];
   const header = { p: p };
@@ -191,8 +189,8 @@ test('create HMac-05', async () => {
 });
 
 test('verify HMac-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-01.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-01.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -201,8 +199,8 @@ test('verify HMac-01', async () => {
 });
 
 test('verify HMac-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-02.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-02.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -211,8 +209,8 @@ test('verify HMac-02', async () => {
 });
 
 test('verify HMac-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-03.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-03.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -221,15 +219,15 @@ test('verify HMac-03', async () => {
 });
 
 test('verify HMac-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-04.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-04.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Tag mismatch' });
 });
 
 test('verify HMac-05', async () => {
-  const example = jsonfile.readFileSync('test/Examples/hmac-examples/HMac-05.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/hmac-examples/HMac-05.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
   assert.ok(Buffer.isBuffer(buf));

--- a/test/mac-tests.js
+++ b/test/mac-tests.js
@@ -5,16 +5,14 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 test('create HMac-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/HMac-01.json');
+  const example = loadExample('test/Examples/mac-tests/HMac-01.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const recipents = [{ key: key, u: u }];
@@ -28,8 +26,8 @@ test('create HMac-01', async () => {
 });
 
 test('verify HMac-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/HMac-01.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/HMac-01.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -39,11 +37,11 @@ test('verify HMac-01', async () => {
 });
 
 test('create mac-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-pass-01.json');
+  const example = loadExample('test/Examples/mac-tests/mac-pass-01.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.unprotected;
   const ru = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const recipents = [{ key: key, u: ru }];
   const header = { p: p, u: u };
@@ -57,12 +55,12 @@ test('create mac-pass-01', async () => {
 });
 
 test('create mac-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-pass-02.json');
+  const example = loadExample('test/Examples/mac-tests/mac-pass-02.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.unprotected;
   const ru = example.input.mac.recipients[0].unprotected;
   const external = Buffer.from(example.input.mac.external, 'hex');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const options = { encodep: 'empty' };
   const header = { p: p, u: u };
@@ -76,11 +74,11 @@ test('create mac-pass-02', async () => {
 });
 
 test('create mac-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-pass-03.json');
+  const example = loadExample('test/Examples/mac-tests/mac-pass-03.json');
   const p = example.input.mac.protected;
   const u = example.input.mac.unprotected;
   const ru = example.input.mac.recipients[0].unprotected;
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const options = { encodep: 'empty', excludetag: true };
   const header = { p: p, u: u };
@@ -95,8 +93,8 @@ test('create mac-pass-03', async () => {
 });
 
 test('verify mac-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-pass-01.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-pass-01.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
   assert.ok(Buffer.isBuffer(buf));
@@ -105,8 +103,8 @@ test('verify mac-pass-01', async () => {
 });
 
 test('verify mac-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-pass-02.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-pass-02.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const external = Buffer.from(example.input.mac.external, 'hex');
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key, external);
@@ -116,8 +114,8 @@ test('verify mac-pass-02', async () => {
 });
 
 test('verify mac-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-pass-03.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-pass-03.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const options = { defaultType: cose.mac.MACTag };
   const external = null;
   const data = example.output.cbor;
@@ -128,43 +126,43 @@ test('verify mac-pass-03', async () => {
 });
 
 test('verify mac-fail-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-fail-01.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-fail-01.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Expecting Array of length 4' });
 });
 
 test('verify mac-fail-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-fail-02.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-fail-02.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Tag mismatch' });
 });
 
 test('verify mac-fail-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-fail-03.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-fail-03.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Unknown algorithm, -999' });
 });
 
 test('verify mac-fail-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-fail-04.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-fail-04.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Unknown algorithm, Unknown' });
 });
 
 test('verify mac-fail-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-fail-06.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-fail-06.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Tag mismatch' });
 });
 
 test('verify mac-fail-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac-tests/mac-fail-07.json');
-  const key = base64url.toBuffer(example.input.mac.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac-tests/mac-fail-07.json');
+  const key = b64url(example.input.mac.recipients[0].key.k);
   const data = example.output.cbor;
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Tag mismatch' });
 });

--- a/test/mac0-tests.js
+++ b/test/mac0-tests.js
@@ -5,16 +5,14 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 test('create HMac-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/HMac-01.json');
+  const example = loadExample('test/Examples/mac0-tests/HMac-01.json');
   const p = example.input.mac0.protected;
   const u = example.input.mac0.unprotected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
 
   const header = { p: p, u: u };
@@ -28,8 +26,8 @@ test('create HMac-01', async () => {
 });
 
 test('verify HMac-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/HMac-01.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/HMac-01.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -39,10 +37,10 @@ test('verify HMac-01', async () => {
 });
 
 test('create mac-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-pass-01.json');
+  const example = loadExample('test/Examples/mac0-tests/mac-pass-01.json');
 
   const u = example.input.mac0.unprotected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const header = { u: u };
   const recipents = { key: key };
@@ -55,11 +53,11 @@ test('create mac-pass-01', async () => {
 });
 
 test('create mac-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-pass-02.json');
+  const example = loadExample('test/Examples/mac0-tests/mac-pass-02.json');
   const p = undefined;
   const u = example.input.mac0.unprotected;
   const external = Buffer.from(example.input.mac0.external, 'hex');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const options = { encodep: 'empty' };
 
@@ -74,10 +72,10 @@ test('create mac-pass-02', async () => {
 });
 
 test('create mac-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-pass-03.json');
+  const example = loadExample('test/Examples/mac0-tests/mac-pass-03.json');
   const p = undefined;
   const u = example.input.mac0.unprotected;
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const plaintext = Buffer.from(example.input.plaintext);
   const options = { encodep: 'empty', excludetag: true };
 
@@ -94,8 +92,8 @@ test('create mac-pass-03', async () => {
 });
 
 test('verify mac-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-pass-01.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-pass-01.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -106,8 +104,8 @@ test('verify mac-pass-01', async () => {
 });
 
 test('verify mac-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-pass-02.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-pass-02.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const external = Buffer.from(example.input.mac0.external, 'hex');
 
   const data = example.output.cbor;
@@ -118,8 +116,8 @@ test('verify mac-pass-02', async () => {
 });
 
 test('verify mac-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-pass-03.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-pass-03.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
 
   const data = example.output.cbor;
   const buf = await cose.mac.read(data, key);
@@ -130,48 +128,48 @@ test('verify mac-pass-03', async () => {
 });
 
 test('verify mac-fail-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-fail-01.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-fail-01.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Unexpected cbor tag, \'992\'' });
 });
 
 test('verify mac-fail-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-fail-02.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-fail-02.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Tag mismatch' });
 });
 
 test('verify mac-fail-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-fail-03.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-fail-03.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Unknown algorithm, -999' });
 });
 
 test('verify mac-fail-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-fail-04.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-fail-04.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Unknown algorithm, Unknown' });
 });
 
 test('verify mac-fail-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-fail-06.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-fail-06.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Tag mismatch' });
 });
 
 test('verify mac-fail-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/mac0-tests/mac-fail-07.json');
-  const key = base64url.toBuffer(example.input.mac0.recipients[0].key.k);
+  const example = loadExample('test/Examples/mac0-tests/mac-fail-07.json');
+  const key = b64url(example.input.mac0.recipients[0].key.k);
   const data = example.output.cbor;
 
   await assert.rejects(() => cose.mac.read(data, key), { message: 'Tag mismatch' });

--- a/test/rsa-pkcs-examples.js
+++ b/test/rsa-pkcs-examples.js
@@ -5,17 +5,16 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
 const jwkToPem = require('jwk-to-pem');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample } = require('./util.js');
 
 function hexToB64 (hex) {
   return Buffer.from(hex, 'hex').toString('base64');
 }
 
 test('create rsa-pkcs-01', async () => {
-  const example = jsonfile.readFileSync('test/rsa-pkcs-examples/rsa-pkcs-01.json');
+  const example = loadExample('test/rsa-pkcs-examples/rsa-pkcs-01.json');
   const p = example.input.sign0.protected;
   const u = example.input.sign0.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -45,7 +44,7 @@ test('create rsa-pkcs-01', async () => {
 });
 
 test('create rsa-pkcs-01 Sync', async () => {
-  const example = jsonfile.readFileSync('test/rsa-pkcs-examples/rsa-pkcs-01.json');
+  const example = loadExample('test/rsa-pkcs-examples/rsa-pkcs-01.json');
   const p = example.input.sign0.protected;
   const u = example.input.sign0.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
@@ -75,7 +74,7 @@ test('create rsa-pkcs-01 Sync', async () => {
 });
 
 test('verify rsa-pkcs-01', async () => {
-  const example = jsonfile.readFileSync('test/rsa-pkcs-examples/rsa-pkcs-01.json');
+  const example = loadExample('test/rsa-pkcs-examples/rsa-pkcs-01.json');
 
   const testKey = example.input.sign0.key;
 
@@ -97,7 +96,7 @@ test('verify rsa-pkcs-01', async () => {
 });
 
 test('verify rsa-pkcs-01 Sync', async () => {
-  const example = jsonfile.readFileSync('test/rsa-pkcs-examples/rsa-pkcs-01.json');
+  const example = loadExample('test/rsa-pkcs-examples/rsa-pkcs-01.json');
 
   const testKey = example.input.sign0.key;
 

--- a/test/sign-performance-tests.js
+++ b/test/sign-performance-tests.js
@@ -5,19 +5,18 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const jsonfile = require('jsonfile');
+const { loadExample, b64url } = require('./util.js');
 
 test('create and verify really huge payload', async () => {
   // uses the keys from here but it has nothing to do with the test
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/ecdsa-01.json');
+  const example = loadExample('test/Examples/sign-tests/ecdsa-01.json');
   const BIG_LENGHT = 100 * 1000;
   const p = example.input.sign.protected;
   const u = example.input.sign.unprotected;
   const signers = [{
     key: {
-      d: base64url.toBuffer(example.input.sign.signers[0].key.d)
+      d: b64url(example.input.sign.signers[0].key.d)
     },
     u: example.input.sign.signers[0].unprotected,
     p: example.input.sign.signers[0].protected
@@ -26,8 +25,8 @@ test('create and verify really huge payload', async () => {
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };

--- a/test/sign-tests.js
+++ b/test/sign-tests.js
@@ -5,18 +5,16 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const deepEqual = require('./util.js').deepEqual;
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 test('ecdsa-examples verify ecdsa-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdsa-examples/ecdsa-01.json');
+  const example = loadExample('test/Examples/ecdsa-examples/ecdsa-01.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -30,12 +28,12 @@ test('ecdsa-examples verify ecdsa-01', async () => {
 });
 
 test('ecdsa-examples verify ecdsa-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/ecdsa-examples/ecdsa-02.json');
+  const example = loadExample('test/Examples/ecdsa-examples/ecdsa-02.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -49,13 +47,13 @@ test('ecdsa-examples verify ecdsa-02', async () => {
 });
 
 test('create ecdsa-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/ecdsa-01.json');
+  const example = loadExample('test/Examples/sign-tests/ecdsa-01.json');
   const p = example.input.sign.protected;
   const u = example.input.sign.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
   const signers = [{
     key: {
-      d: base64url.toBuffer(example.input.sign.signers[0].key.d)
+      d: b64url(example.input.sign.signers[0].key.d)
     },
     u: example.input.sign.signers[0].unprotected,
     p: example.input.sign.signers[0].protected
@@ -71,7 +69,7 @@ test('create ecdsa-01', async () => {
 });
 
 test('sign+verify rsa-pss-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/rsa-pss-examples/rsa-pss-01.json');
+  const example = loadExample('test/Examples/rsa-pss-examples/rsa-pss-01.json');
   const p = example.input.sign.protected;
 
   const u = example.input.sign.unprotected;
@@ -105,7 +103,7 @@ test('sign+verify rsa-pss-01', async () => {
 });
 
 test('sign+verify rsa-pss-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/rsa-pss-examples/rsa-pss-02.json');
+  const example = loadExample('test/Examples/rsa-pss-examples/rsa-pss-02.json');
   const p = example.input.sign.protected;
 
   const u = example.input.sign.unprotected;
@@ -138,7 +136,7 @@ test('sign+verify rsa-pss-02', async () => {
   assert.strictEqual(verifiedBuf.toString('utf8'), example.input.plaintext);
 });
 test('sign+verify rsa-pss-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/rsa-pss-examples/rsa-pss-03.json');
+  const example = loadExample('test/Examples/rsa-pss-examples/rsa-pss-03.json');
   const p = example.input.sign.protected;
 
   const u = example.input.sign.unprotected;
@@ -172,12 +170,12 @@ test('sign+verify rsa-pss-03', async () => {
 });
 
 test('verify ecdsa-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/ecdsa-01.json');
+  const example = loadExample('test/Examples/sign-tests/ecdsa-01.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -191,14 +189,14 @@ test('verify ecdsa-01', async () => {
 });
 
 test('create sign-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-01.json');
+  const example = loadExample('test/Examples/sign-tests/sign-pass-01.json');
   const p = example.input.sign.protected;
   const u = example.input.sign.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const signers = [{
     key: {
-      d: base64url.toBuffer(example.input.sign.signers[0].key.d)
+      d: b64url(example.input.sign.signers[0].key.d)
     },
     u: example.input.sign.signers[0].unprotected,
     p: example.input.sign.signers[0].protected
@@ -214,14 +212,14 @@ test('create sign-pass-01', async () => {
 });
 
 test('create sign-pass-01 Sync', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-01.json');
+  const example = loadExample('test/Examples/sign-tests/sign-pass-01.json');
   const p = example.input.sign.protected;
   const u = example.input.sign.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const signers = [{
     key: {
-      d: base64url.toBuffer(example.input.sign.signers[0].key.d)
+      d: b64url(example.input.sign.signers[0].key.d)
     },
     u: example.input.sign.signers[0].unprotected,
     p: example.input.sign.signers[0].protected
@@ -237,13 +235,13 @@ test('create sign-pass-01 Sync', async () => {
 });
 
 test('create sign-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-02.json');
+  const example = loadExample('test/Examples/sign-tests/sign-pass-02.json');
   const p = example.input.sign.protected;
   const u = example.input.sign.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const signers = [{
-    key: { d: base64url.toBuffer(example.input.sign.signers[0].key.d) },
+    key: { d: b64url(example.input.sign.signers[0].key.d) },
     u: example.input.sign.signers[0].unprotected,
     p: example.input.sign.signers[0].protected,
     externalAAD: Buffer.from(example.input.sign.signers[0].external, 'hex')
@@ -260,14 +258,14 @@ test('create sign-pass-02', async () => {
 });
 
 test('create sign-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-03.json');
+  const example = loadExample('test/Examples/sign-tests/sign-pass-03.json');
   const p = example.input.sign.protected;
   const u = example.input.sign.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const signers = [{
     key: {
-      d: base64url.toBuffer(example.input.sign.signers[0].key.d)
+      d: b64url(example.input.sign.signers[0].key.d)
     },
     u: example.input.sign.signers[0].unprotected,
     p: example.input.sign.signers[0].protected
@@ -284,12 +282,12 @@ test('create sign-pass-03', async () => {
 });
 
 test('verify sign-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-01.json');
+  const example = loadExample('test/Examples/sign-tests/sign-pass-01.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -303,12 +301,12 @@ test('verify sign-pass-01', async () => {
 });
 
 test('verify sign-pass-01 Sync', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-01.json');
+  const example = loadExample('test/Examples/sign-tests/sign-pass-01.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -322,12 +320,12 @@ test('verify sign-pass-01 Sync', async () => {
 });
 
 test('verify sign-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-02.json');
+  const example = loadExample('test/Examples/sign-tests/sign-pass-02.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     },
     externalAAD: Buffer.from(example.input.sign.signers[0].external, 'hex')
@@ -342,12 +340,12 @@ test('verify sign-pass-02', async () => {
 });
 
 test('verify sign-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-pass-03.json');
+  const example = loadExample('test/Examples/sign-tests/sign-pass-03.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -361,12 +359,12 @@ test('verify sign-pass-03', async () => {
 });
 
 test('verify sign-fail-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-fail-01.json');
+  const example = loadExample('test/Examples/sign-tests/sign-fail-01.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -376,12 +374,12 @@ test('verify sign-fail-01', async () => {
 });
 
 test('verify sign-fail-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-fail-02.json');
+  const example = loadExample('test/Examples/sign-tests/sign-fail-02.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -391,12 +389,12 @@ test('verify sign-fail-02', async () => {
 });
 
 test('verify sign-fail-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-fail-03.json');
+  const example = loadExample('test/Examples/sign-tests/sign-fail-03.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -406,12 +404,12 @@ test('verify sign-fail-03', async () => {
 });
 
 test('verify sign-fail-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-fail-04.json');
+  const example = loadExample('test/Examples/sign-tests/sign-fail-04.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -421,12 +419,12 @@ test('verify sign-fail-04', async () => {
 });
 
 test('verify sign-fail-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-fail-06.json');
+  const example = loadExample('test/Examples/sign-tests/sign-fail-06.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -436,12 +434,12 @@ test('verify sign-fail-06', async () => {
 });
 
 test('verify sign-fail-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign-tests/sign-fail-07.json');
+  const example = loadExample('test/Examples/sign-tests/sign-fail-07.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign.signers[0].key.x),
-      y: base64url.toBuffer(example.input.sign.signers[0].key.y),
+      x: b64url(example.input.sign.signers[0].key.x),
+      y: b64url(example.input.sign.signers[0].key.y),
       kid: example.input.sign.signers[0].key.kid
     }
   };
@@ -451,7 +449,7 @@ test('verify sign-fail-07', async () => {
 });
 
 test('verify rsa-pss-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/rsa-pss-examples/rsa-pss-01.json');
+  const example = loadExample('test/Examples/rsa-pss-examples/rsa-pss-01.json');
 
   const verifier = {
     key: {
@@ -470,7 +468,7 @@ test('verify rsa-pss-01', async () => {
 });
 
 test('verify rsa-pss-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/rsa-pss-examples/rsa-pss-02.json');
+  const example = loadExample('test/Examples/rsa-pss-examples/rsa-pss-02.json');
 
   const verifier = {
     key: {
@@ -489,7 +487,7 @@ test('verify rsa-pss-02', async () => {
 });
 
 test('verify rsa-pss-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/rsa-pss-examples/rsa-pss-03.json');
+  const example = loadExample('test/Examples/rsa-pss-examples/rsa-pss-03.json');
 
   const verifier = {
     key: {

--- a/test/sign1-tests.js
+++ b/test/sign1-tests.js
@@ -5,19 +5,17 @@
 const cose = require('../');
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const jsonfile = require('jsonfile');
-const base64url = require('base64url');
 const cbor = require('cbor');
-const { deepEqual } = require('./util.js');
+const { deepEqual, loadExample, b64url } = require('./util.js');
 
 test('create sign-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-pass-01.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-pass-01.json');
   const u = example.input.sign0.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const signer = {
     key: {
-      d: base64url.toBuffer(example.input.sign0.key.d)
+      d: b64url(example.input.sign0.key.d)
     }
   };
 
@@ -31,14 +29,14 @@ test('create sign-pass-01', async () => {
 });
 
 test('create sign-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-pass-02.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-pass-02.json');
   const p = example.input.sign0.protected;
   const u = example.input.sign0.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const signer = {
     key: {
-      d: base64url.toBuffer(example.input.sign0.key.d)
+      d: b64url(example.input.sign0.key.d)
     },
     externalAAD: Buffer.from(example.input.sign0.external, 'hex')
   };
@@ -53,14 +51,14 @@ test('create sign-pass-02', async () => {
 });
 
 test('create sign-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-pass-03.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-pass-03.json');
   const p = example.input.sign0.protected;
   const u = example.input.sign0.unprotected;
   const plaintext = Buffer.from(example.input.plaintext);
 
   const signer = {
     key: {
-      d: base64url.toBuffer(example.input.sign0.key.d)
+      d: b64url(example.input.sign0.key.d)
     }
   };
 
@@ -75,12 +73,12 @@ test('create sign-pass-03', async () => {
 });
 
 test('verify sign-pass-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-pass-01.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-pass-01.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     }
   };
 
@@ -93,12 +91,12 @@ test('verify sign-pass-01', async () => {
 });
 
 test('verify sign-pass-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-pass-02.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-pass-02.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     },
     externalAAD: Buffer.from(example.input.sign0.external, 'hex')
   };
@@ -112,12 +110,12 @@ test('verify sign-pass-02', async () => {
 });
 
 test('verify sign-pass-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-pass-03.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-pass-03.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     }
   };
 
@@ -131,12 +129,12 @@ test('verify sign-pass-03', async () => {
 });
 
 test('verify sign-fail-01', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-fail-01.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-fail-01.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     }
   };
 
@@ -145,12 +143,12 @@ test('verify sign-fail-01', async () => {
 });
 
 test('verify sign-fail-02', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-fail-02.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-fail-02.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     }
   };
 
@@ -159,12 +157,12 @@ test('verify sign-fail-02', async () => {
 });
 
 test('verify sign-fail-03', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-fail-03.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-fail-03.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     }
   };
 
@@ -173,12 +171,12 @@ test('verify sign-fail-03', async () => {
 });
 
 test('verify sign-fail-04', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-fail-04.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-fail-04.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     }
   };
 
@@ -187,12 +185,12 @@ test('verify sign-fail-04', async () => {
 });
 
 test('verify sign-fail-06', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-fail-06.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-fail-06.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     }
   };
 
@@ -201,12 +199,12 @@ test('verify sign-fail-06', async () => {
 });
 
 test('verify sign-fail-07', async () => {
-  const example = jsonfile.readFileSync('test/Examples/sign1-tests/sign-fail-07.json');
+  const example = loadExample('test/Examples/sign1-tests/sign-fail-07.json');
 
   const verifier = {
     key: {
-      x: base64url.toBuffer(example.input.sign0.key.x),
-      y: base64url.toBuffer(example.input.sign0.key.y)
+      x: b64url(example.input.sign0.key.x),
+      y: b64url(example.input.sign0.key.y)
     }
   };
 

--- a/test/util.js
+++ b/test/util.js
@@ -80,6 +80,19 @@ function deepEqual (actual, expected, depth) {
 
 exports.deepEqual = deepEqual;
 
+const { readFileSync } = require('fs');
+
+function loadExample (path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function b64url (str) {
+  return Buffer.from(str, 'base64url');
+}
+
+exports.loadExample = loadExample;
+exports.b64url = b64url;
+
 test('deep equal array', () => {
   const actual = [1, 2, 3, '4', [1, 2, 3], { hello: 'world', world: 'hello' }];
   const expected = [1, 2, 3, '4', [1, 2, 3], { hello: 'world', world: 'hello' }];


### PR DESCRIPTION
## Summary
- **Remove 3 dependencies** replaced with Node.js built-ins:
  - `node-hkdf-sync` (prod) → `crypto.hkdfSync()`
  - `jsonfile` (dev) → `fs.readFileSync()` + `JSON.parse()`
  - `base64url` (dev) → `Buffer.from(str, 'base64url')`
- **Update all remaining dependencies to latest:**
  - cbor 8.1.0 → 10.0.12
  - elliptic 6.5.4 → 6.6.1
  - nyc 15.1.0 → 18.0.0
  - semistandard 16.0.1 → 17.0.0
  - jwk-to-pem 2.0.5 → 2.0.7
  - live-server 1.2.1 → 1.2.2

## Test plan
- [x] All 245 tests pass locally
- [x] `npm outdated` reports no outdated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)